### PR TITLE
feat: move backtest filtering to URL parameters

### DIFF
--- a/apps/modeling-app/src/components/BacktestsTable/BacktestsTable.tsx
+++ b/apps/modeling-app/src/components/BacktestsTable/BacktestsTable.tsx
@@ -32,6 +32,7 @@ import { BacktestActionsMenu } from './BacktestActionsMenu';
 import { BacktestsTableFilters } from './BacktestsTableFilters';
 import { BatchActions } from './BatchActions';
 import { RunningJobsIndicator } from './RunningJobsIndicator';
+import { useBacktestsTableFilters } from './hooks/useBacktestsTableFilters';
 
 const columnHelper = createColumnHelper<BackTestRead>();
 
@@ -122,11 +123,17 @@ type Props = {
 
 export const BacktestsTable = ({ backtests, models }: Props) => {
     const navigate = useNavigate();
+    const { modelId, search } = useBacktestsTableFilters();
+
     const table = useReactTable({
         data: backtests || [],
         columns,
         initialState: {
             sorting: [{ id: 'created', desc: true }],
+            columnFilters: [
+                ...(modelId ? [{ id: 'modelId', value: modelId }] : []),
+                ...(search ? [{ id: 'name', value: search }] : []),
+            ],
         },
         meta: {
             models,

--- a/apps/modeling-app/src/components/BacktestsTable/BacktestsTableFilters/BacktestsTableFilters.tsx
+++ b/apps/modeling-app/src/components/BacktestsTable/BacktestsTableFilters/BacktestsTableFilters.tsx
@@ -8,6 +8,7 @@ import i18n from '@dhis2/d2-i18n';
 import { Table } from '@tanstack/react-table';
 import { BackTestRead, ModelSpecRead } from '@dhis2-chap/ui';
 import styles from './BacktestsTableFilters.module.css';
+import { useBacktestsTableFilters } from '../hooks/useBacktestsTableFilters';
 
 type Props = {
     table: Table<BackTestRead>;
@@ -15,6 +16,19 @@ type Props = {
 };
 
 export const BacktestsTableFilters = ({ table, models }: Props) => {
+    const { setModelId, setSearch } = useBacktestsTableFilters();
+
+    const handleSearchChange = (value: string | undefined) => {
+        const searchValue = value || undefined;
+        table.getColumn('name')?.setFilterValue(searchValue);
+        setSearch(searchValue);
+    };
+
+    const handleModelChange = (selected: string | undefined) => {
+        table.getColumn('modelId')?.setFilterValue(selected);
+        setModelId(selected);
+    };
+
     return (
         <>
             <div className={styles.inputContainer}>
@@ -22,7 +36,7 @@ export const BacktestsTableFilters = ({ table, models }: Props) => {
                     dense
                     placeholder={i18n.t('Search')}
                     value={(table.getColumn('name')?.getFilterValue() as string | undefined) ?? ''}
-                    onChange={e => table.getColumn('name')?.setFilterValue(e.value)}
+                    onChange={e => handleSearchChange(e.value)}
                 />
             </div>
 
@@ -35,7 +49,7 @@ export const BacktestsTableFilters = ({ table, models }: Props) => {
                     clearText={i18n.t('Clear')}
                     selected={table.getColumn('modelId')?.getFilterValue() as string | undefined}
                     placeholder={i18n.t('Model')}
-                    onChange={e => table.getColumn('modelId')?.setFilterValue(e.selected)}
+                    onChange={e => handleModelChange(e.selected)}
                 >
                     {models.map(model => (
                         <MenuItem

--- a/apps/modeling-app/src/components/BacktestsTable/hooks/useBacktestsTableFilters.ts
+++ b/apps/modeling-app/src/components/BacktestsTable/hooks/useBacktestsTableFilters.ts
@@ -1,0 +1,54 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const PARAM_KEYS = {
+    modelId: 'modelId',
+    search: 'search',
+};
+
+export const useBacktestsTableFilters = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const modelId = searchParams.get(PARAM_KEYS.modelId) || undefined;
+    const search = searchParams.get(PARAM_KEYS.search) || undefined;
+
+    const setModelId = useCallback(
+        (newModelId: string | undefined) => {
+            setSearchParams((prev) => {
+                const updatedParams = new URLSearchParams(prev);
+                if (newModelId) {
+                    updatedParams.set(PARAM_KEYS.modelId, newModelId);
+                } else {
+                    updatedParams.delete(PARAM_KEYS.modelId);
+                }
+                return updatedParams;
+            });
+        },
+        [setSearchParams],
+    );
+
+    const setSearch = useCallback(
+        (newSearch: string | undefined) => {
+            setSearchParams((prev) => {
+                const updatedParams = new URLSearchParams(prev);
+                if (newSearch) {
+                    updatedParams.set(PARAM_KEYS.search, newSearch);
+                } else {
+                    updatedParams.delete(PARAM_KEYS.search);
+                }
+                return updatedParams;
+            });
+        },
+        [setSearchParams],
+    );
+
+    return useMemo(
+        () => ({
+            modelId,
+            setModelId,
+            search,
+            setSearch,
+        }),
+        [modelId, setModelId, search, setSearch],
+    );
+};


### PR DESCRIPTION
## Summary
This PR implements URL-based filtering for the backtests table, allowing filter state to persist across page refreshes and be shareable via URL.

## Changes
- [x] Created custom hook `useBacktestsTableFilters` to manage filter state in URL parameters
- [x] Synced table filters (model and search) with URL query parameters
- [x] Integrated URL filters with table initial state
- [x] Updated filter handlers to update both table state and URL

## Benefits
- Filter state persists across page refreshes
- Filters are shareable via URL
- Better user experience when navigating back to the table
- Cleaner separation of concerns with custom hook

## Testing
- [x] Manual testing completed
- [x] Verified filters sync with URL
- [x] Verified filters persist on refresh
- [x] Verified clearing filters removes URL params