### PR TITLE
fix: update e2e DHIS2 test database

### DIFF
--- a/.github/workflows/e2e-stable.yml
+++ b/.github/workflows/e2e-stable.yml
@@ -14,12 +14,6 @@ concurrency:
 
 env:
     CHAP_CORE_STABLE_REF: v1.3.0
-    DHIS2_DB_DUMP_URL: https://databases.dhis2.org/climate/laos/2.42/demo.sql.gz
-    DHIS2_IMAGE: dhis2/core:2.42
-    DHIS2_ANALYTICS_USERNAME: system
-    DHIS2_ANALYTICS_PASSWORD: System123
-    E2E_DHIS2_USERNAME: system
-    E2E_DHIS2_PASSWORD: System123
 
 jobs:
     e2e-stable:

--- a/.github/workflows/e2e-stable.yml
+++ b/.github/workflows/e2e-stable.yml
@@ -14,6 +14,12 @@ concurrency:
 
 env:
     CHAP_CORE_STABLE_REF: v1.3.0
+    DHIS2_DB_DUMP_URL: https://databases.dhis2.org/climate/laos/2.42/demo.sql.gz
+    DHIS2_IMAGE: dhis2/core:2.42
+    DHIS2_ANALYTICS_USERNAME: system
+    DHIS2_ANALYTICS_PASSWORD: System123
+    E2E_DHIS2_USERNAME: system
+    E2E_DHIS2_PASSWORD: System123
 
 jobs:
     e2e-stable:

--- a/apps/modeling-app/e2e/README.md
+++ b/apps/modeling-app/e2e/README.md
@@ -28,4 +28,4 @@ pnpm docker:e2e reset
 - `E2E_APP_URL` (default: `http://localhost:3000`)
 - `E2E_DHIS2_BASE_URL` (default: `http://localhost:8080`)
 - `E2E_DHIS2_USERNAME` (default: `system`)
-- `E2E_DHIS2_PASSWORD` (default: `S&stem123!`)
+- `E2E_DHIS2_PASSWORD` (default: `System123`)

--- a/apps/modeling-app/e2e/auth.setup.ts
+++ b/apps/modeling-app/e2e/auth.setup.ts
@@ -5,7 +5,7 @@ import { getAppOrigin } from './config';
 
 const DEFAULT_DHIS2_BASE_URL = 'http://localhost:8080';
 const DEFAULT_DHIS2_USERNAME = 'system';
-const DEFAULT_DHIS2_PASSWORD = 'S&stem123!';
+const DEFAULT_DHIS2_PASSWORD = 'System123';
 const AUTH_FILE = path.resolve(__dirname, '../../../playwright/.auth/user.json');
 
 const normalizeBaseUrl = (url: string): string => url.replace(/\/+$/, '');

--- a/docker/compose.dhis2.yml
+++ b/docker/compose.dhis2.yml
@@ -8,7 +8,7 @@ services:
         "if [ -f dhis2-demo.dump.gz ]; then echo 'dhis2-demo.dump.gz exists'; exit 0; fi; if [ -f demo.sql.gz ]; then mv demo.sql.gz dhis2-demo.dump.gz; else wget --output-document dhis2-demo.dump.gz \"$$DHIS2_DB_DUMP_URL\"; fi; echo 'Prepared dhis2-demo.dump.gz'",
       ]
     environment:
-      DHIS2_DB_DUMP_URL: ${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/climate/laos/2.41.7/demo.sql.gz}
+      DHIS2_DB_DUMP_URL: ${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/climate/laos/2.42/demo.sql.gz}
     working_dir: /opt/dump
     volumes:
       - dhis2-db-dump:/opt/dump
@@ -41,7 +41,7 @@ services:
 
   dhis2-web:
     platform: linux/amd64
-    image: ${DHIS2_IMAGE:-dhis2/core:2.41.7}
+    image: ${DHIS2_IMAGE:-dhis2/core:2.42}
     restart: unless-stopped
     depends_on:
       dhis2-db:
@@ -71,7 +71,7 @@ services:
     environment:
       BASE_URL: http://dhis2-web:8080
       USERNAME: ${DHIS2_ANALYTICS_USERNAME:-system}
-      PASSWORD: "${DHIS2_ANALYTICS_PASSWORD:-S&stem123!}"
+      PASSWORD: "${DHIS2_ANALYTICS_PASSWORD:-System123}"
       DHIS2_ANALYTICS_LAST_YEARS: ${DHIS2_ANALYTICS_LAST_YEARS:-8}
       DHIS2_ANALYTICS_POLL_INTERVAL_SECONDS: ${DHIS2_ANALYTICS_POLL_INTERVAL_SECONDS:-5}
       DHIS2_ANALYTICS_MAX_POLL_TRIES: ${DHIS2_ANALYTICS_MAX_POLL_TRIES:-360}

--- a/docker/dhis.conf
+++ b/docker/dhis.conf
@@ -7,3 +7,4 @@ connection.password = dhis
 max.sessions.per_user = 100
 flyway.repair_before_migration=ON
 flyway.migrate_out_of_order=true
+route.remote_servers_allowed = http://chap:8000

--- a/docker/scripts/generate_analytics_tables.sh
+++ b/docker/scripts/generate_analytics_tables.sh
@@ -10,7 +10,9 @@ ROUTE_NAME="${DHIS2_ROUTE_NAME}"
 ROUTE_CODE="${DHIS2_ROUTE_CODE}"
 ROUTE_URL="${DHIS2_ROUTE_URL}"
 ANALYTICS_TRIGGER_RESPONSE_FILE="/tmp/dhis2-analytics-trigger-response.json"
+ROUTE_LOOKUP_RESPONSE_FILE="/tmp/dhis2-route-lookup-response.json"
 ROUTE_CREATE_RESPONSE_FILE="/tmp/dhis2-route-create-response.json"
+ROUTE_UPDATE_RESPONSE_FILE="/tmp/dhis2-route-update-response.json"
 
 ANALYTICS_TRIGGER_STATUS=$(
     curl --silent --show-error \
@@ -53,34 +55,75 @@ while true; do
     sleep "$POLL_INTERVAL_SECONDS"
 done
 
-echo "Creating DHIS2 route '${ROUTE_CODE}' -> '${ROUTE_URL}'" 1>&2
+ROUTE_PAYLOAD=$(jq -n \
+    --arg name "${ROUTE_NAME}" \
+    --arg code "${ROUTE_CODE}" \
+    --arg url "${ROUTE_URL}" \
+    '{
+        name: $name,
+        code: $code,
+        url: $url,
+        authorities: ["F_CHAP_MODELING_APP"],
+        headers: { "Content-Type": "application/json" },
+        responseTimeoutSeconds: 30
+    }')
 
-CREATE_ROUTE_STATUS=$(
+ROUTE_LOOKUP_STATUS=$(
     curl --silent --show-error \
-        --output "${ROUTE_CREATE_RESPONSE_FILE}" \
+        --output "${ROUTE_LOOKUP_RESPONSE_FILE}" \
         --write-out "%{http_code}" \
         --user "$CREDENTIALS" \
-        --header "Content-Type: application/json" \
-        --request POST \
-        --data "$(jq -n \
-            --arg name "${ROUTE_NAME}" \
-            --arg code "${ROUTE_CODE}" \
-            --arg url "${ROUTE_URL}" \
-            '{
-                name: $name,
-                code: $code,
-                url: $url,
-                authorities: ["F_CHAP_MODELING_APP"],
-                headers: { "Content-Type": "application/json" },
-                responseTimeoutSeconds: 30
-            }')" \
-        "$BASE_URL/api/routes"
+        "$BASE_URL/api/routes?fields=id&filter=code:eq:${ROUTE_CODE}"
 )
 
-if [[ "$CREATE_ROUTE_STATUS" != "201" ]]; then
-    echo "Failed to create DHIS2 route; expected HTTP 201, got ${CREATE_ROUTE_STATUS}" 1>&2
-    cat "${ROUTE_CREATE_RESPONSE_FILE}" 1>&2 || true
+if [[ "$ROUTE_LOOKUP_STATUS" != "200" ]]; then
+    echo "Failed to look up DHIS2 route '${ROUTE_CODE}'; expected HTTP 200, got ${ROUTE_LOOKUP_STATUS}" 1>&2
+    cat "${ROUTE_LOOKUP_RESPONSE_FILE}" 1>&2 || true
     exit 1
 fi
 
-echo "DHIS2 route '${ROUTE_CODE}' created (HTTP 201)" 1>&2
+EXISTING_ROUTE_ID=$(jq -r '.routes[0].id // empty' "${ROUTE_LOOKUP_RESPONSE_FILE}")
+
+if [[ -n "$EXISTING_ROUTE_ID" ]]; then
+    echo "Updating DHIS2 route '${ROUTE_CODE}' (${EXISTING_ROUTE_ID}) -> '${ROUTE_URL}'" 1>&2
+
+    UPDATE_ROUTE_STATUS=$(
+        curl --silent --show-error \
+            --output "${ROUTE_UPDATE_RESPONSE_FILE}" \
+            --write-out "%{http_code}" \
+            --user "$CREDENTIALS" \
+            --header "Content-Type: application/json" \
+            --request PUT \
+            --data "$(echo "$ROUTE_PAYLOAD" | jq --arg id "$EXISTING_ROUTE_ID" '. + { id: $id }')" \
+            "$BASE_URL/api/routes/${EXISTING_ROUTE_ID}"
+    )
+
+    if [[ "$UPDATE_ROUTE_STATUS" != "200" && "$UPDATE_ROUTE_STATUS" != "204" ]]; then
+        echo "Failed to update DHIS2 route '${ROUTE_CODE}'; expected HTTP 200/204, got ${UPDATE_ROUTE_STATUS}" 1>&2
+        cat "${ROUTE_UPDATE_RESPONSE_FILE}" 1>&2 || true
+        exit 1
+    fi
+
+    echo "DHIS2 route '${ROUTE_CODE}' updated (HTTP ${UPDATE_ROUTE_STATUS})" 1>&2
+else
+    echo "Creating DHIS2 route '${ROUTE_CODE}' -> '${ROUTE_URL}'" 1>&2
+
+    CREATE_ROUTE_STATUS=$(
+        curl --silent --show-error \
+            --output "${ROUTE_CREATE_RESPONSE_FILE}" \
+            --write-out "%{http_code}" \
+            --user "$CREDENTIALS" \
+            --header "Content-Type: application/json" \
+            --request POST \
+            --data "$ROUTE_PAYLOAD" \
+            "$BASE_URL/api/routes"
+    )
+
+    if [[ "$CREATE_ROUTE_STATUS" != "201" ]]; then
+        echo "Failed to create DHIS2 route; expected HTTP 201, got ${CREATE_ROUTE_STATUS}" 1>&2
+        cat "${ROUTE_CREATE_RESPONSE_FILE}" 1>&2 || true
+        exit 1
+    fi
+
+    echo "DHIS2 route '${ROUTE_CODE}' created (HTTP 201)" 1>&2
+fi


### PR DESCRIPTION
## Summary
- Update the DHIS2 e2e stack defaults to use the Laos 2.42 demo database and `system` / `System123` credentials.
- Allow the local CHAP service as a DHIS2 2.42 route target.
- Make route setup idempotent by updating an existing `chap` route from the seeded database instead of failing on duplicate code/name.

## Validation
- `pnpm linter:check`
- `pnpm --filter @dhis2-chap/ui build`
- `pnpm --filter @dhis2-chap/modeling-app tsc:check`
- `pnpm --filter @dhis2-chap/modeling-app build`
- `COMPOSE_PROJECT_NAME=chap-platform-codex CHAP_PORT=18000 DHIS2_PORT=18080 pnpm docker:e2e up --wait`
- `CI=true E2E_DHIS2_BASE_URL=http://localhost:18080 pnpm e2e:ci`