### PR TITLE
refactor: register Highcharts modules lazily instead of at import time

### DIFF
--- a/packages/ui/src/components/evaluation/ResultPlot/ResultPlot.tsx
+++ b/packages/ui/src/components/evaluation/ResultPlot/ResultPlot.tsx
@@ -4,9 +4,7 @@ import Highcharts from 'highcharts';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { HighChartsData } from '../../../interfaces/Evaluation';
 import { getPeriodNameFromId } from '../../../utils/Time';
-import enableOfflineExporting from 'highcharts/modules/offline-exporting';
-
-enableOfflineExporting(Highcharts);
+import { registerHighchartsModules } from '../../../utils/registerHighchartsModules';
 
 export interface ZoomRange {
     min: number;
@@ -184,6 +182,8 @@ function ResultPlotBase({
     zoomRange,
     onZoomChange,
 }: ResultPlotProps) {
+    registerHighchartsModules();
+
     const chartRef = useRef<HighchartsReact.RefObject | null>(null);
 
     const handleAfterSetExtremes = useCallback(

--- a/packages/ui/src/components/predictions/UncertaintyAreaChart/UncertaintyAreaChart.tsx
+++ b/packages/ui/src/components/predictions/UncertaintyAreaChart/UncertaintyAreaChart.tsx
@@ -1,17 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import Highcharts from 'highcharts';
-import accessibility from 'highcharts/modules/accessibility';
-import highchartsMore from 'highcharts/highcharts-more';
-import exporting from 'highcharts/modules/exporting';
 import HighchartsReact from 'highcharts-react-official';
 import { PredictionOrgUnitSeries } from '../../../interfaces/Prediction';
+import { registerHighchartsModules } from '../../../utils/registerHighchartsModules';
 import type { SupportedOutbreakProbabilityBucket } from '../../../utils/outbreakAlerts';
 import type { ZoomRange } from '../../evaluation/ResultPlot/ResultPlot';
-
-accessibility(Highcharts);
-exporting(Highcharts);
-highchartsMore(Highcharts);
 
 type DisabledAnimationOptions = {
     chart: {
@@ -274,6 +268,8 @@ export const UncertaintyAreaChart = ({
     onZoomChange,
     maxY,
 }: PredicationChartProps) => {
+    registerHighchartsModules();
+
     const chartRef = useRef<HighchartsReact.RefObject | null>(null);
 
     const handleAfterSetExtremes = useCallback(

--- a/packages/ui/src/utils/registerHighchartsModules.ts
+++ b/packages/ui/src/utils/registerHighchartsModules.ts
@@ -1,0 +1,32 @@
+import Highcharts from 'highcharts';
+import accessibility from 'highcharts/modules/accessibility';
+import exporting from 'highcharts/modules/exporting';
+import offlineExporting from 'highcharts/modules/offline-exporting';
+import highchartsMore from 'highcharts/highcharts-more';
+
+/**
+ * Registers the Highcharts feature modules used across the chart components.
+ *
+ * These were previously invoked at module top level, which meant importing any
+ * chart (or the package barrel that re-exports them) eagerly executed the
+ * registration. That made the modules impossible to import outside a browser
+ * (e.g. in unit tests) and defeated tree-shaking. Calling this lazily from a
+ * chart's render keeps the registration out of the import path while still
+ * guaranteeing the modules are active before the first chart is drawn.
+ *
+ * `offline-exporting` extends `exporting`, so `exporting` must be registered
+ * first. The guard makes repeated calls cheap and idempotent.
+ */
+let modulesRegistered = false;
+
+export const registerHighchartsModules = () => {
+    if (modulesRegistered) {
+        return;
+    }
+    modulesRegistered = true;
+
+    accessibility(Highcharts);
+    exporting(Highcharts);
+    offlineExporting(Highcharts);
+    highchartsMore(Highcharts);
+};


### PR DESCRIPTION
## Summary

Moves Highcharts feature-module registration out of the import path. The chart components (`UncertaintyAreaChart`, `ResultPlot`) called `accessibility`/`exporting`/`offline-exporting`/`highcharts-more` at module top level, so importing **any** chart — or the `@dhis2-chap/ui` barrel that re-exports them — eagerly executed the registration. That had two costs:

- The package crashed when imported outside a browser (e.g. `node`/unit tests) — the original `Core/Globals.js` failure.
- It defeated tree-shaking, since the side effects ran on import regardless of whether a chart was used.

It also hid an accidental coupling: `ResultPlot` registered only `offline-exporting`, but that module depends on the base `exporting` module — which was only present because `UncertaintyAreaChart`'s import happened to register it.

## Changes

- New `registerHighchartsModules()` helper — idempotent, registers the full set both charts effectively depend on today (`exporting` before `offline-exporting`).
- `UncertaintyAreaChart` and `ResultPlot` call it at the top of their render instead of at module top level.
- Importing the barrel no longer runs any Highcharts side effects.

## Behavior preservation

Today, importing the barrel evaluates both chart modules, so all four Highcharts modules are registered app-wide as soon as `@dhis2-chap/ui` is imported. Registering the same union from each chart's render faithfully reproduces that — and removes the cross-file accidental dependency.

## Verification

- `pnpm build` (core → ui → app), `tsc:check`, `pnpm test` (91), `linter:check` — all pass.
- Confirmed the built chart files have no top-level module calls, and `require()`-ing the built barrel in node no longer crashes on Highcharts (it now gets past Highcharts entirely).

> [!NOTE]
> I could not run the charts in the live DHIS2 app (needs a backend), so please sanity-check that the uncertainty/result charts still render with the export menu and accessibility features when reviewing.

Base branch is `eh/feat/add-ready-to-predict-page` (this stacks on the `@dhis2-chap/core` extraction work).