### PR TITLE
feat: suggest quantile data elements in setup forms [CLIM-757]

### DIFF
--- a/.changeset/suggest-quantile-data-elements.md
+++ b/.changeset/suggest-quantile-data-elements.md
@@ -1,0 +1,5 @@
+---
+'@dhis2-chap/modeling-app': minor
+---
+
+Suggest matching DHIS2 data elements when configuring quantile import mappings for prediction setup creation, editing, and prediction run imports.

--- a/apps/modeling-app/i18n/en.pot
+++ b/apps/modeling-app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-30T19:01:31.856Z\n"
-"PO-Revision-Date: 2026-05-30T19:01:31.859Z\n"
+"POT-Creation-Date: 2026-05-30T20:08:29.754Z\n"
+"PO-Revision-Date: 2026-05-30T20:08:29.755Z\n"
 
 msgid "Create new..."
 msgstr "Create new..."
@@ -358,6 +358,40 @@ msgstr "All org units must be at the same level"
 msgid "Confirm Selection"
 msgstr "Confirm Selection"
 
+msgid "Production"
+msgstr "Production"
+
+msgid "Approved for general use."
+msgstr "Approved for general use."
+
+msgid "Testing"
+msgstr "Testing"
+
+msgid "Prepared for more extensive testing; not yet approved for production."
+msgstr "Prepared for more extensive testing; not yet approved for production."
+
+msgid "Limited"
+msgstr "Limited"
+
+msgid "Tested on a small dataset. Requires manual tuning and close monitoring."
+msgstr "Tested on a small dataset. Requires manual tuning and close monitoring."
+
+msgid "Experimental"
+msgstr "Experimental"
+
+msgid ""
+"An early prototype with no formal validation - only for initial "
+"experimentation."
+msgstr ""
+"An early prototype with no formal validation - only for initial "
+"experimentation."
+
+msgid "Deprecated"
+msgstr "Deprecated"
+
+msgid "This model is not intended for use or has been deprecated."
+msgstr "This model is not intended for use or has been deprecated."
+
 msgid "Monthly"
 msgstr "Monthly"
 
@@ -370,63 +404,20 @@ msgstr "Weekly"
 msgid "Daily"
 msgstr "Daily"
 
-msgid "Any"
-msgstr "Any"
-
-msgid "Deprecated"
-msgstr "Deprecated"
-
-msgid "This model is not intended for use or has been deprecated."
-msgstr "This model is not intended for use or has been deprecated."
-
-msgid "Experimental"
-msgstr "Experimental"
-
-msgid ""
-"An early prototype with no formal validation - only for initial "
-"experimentation."
-msgstr ""
-"An early prototype with no formal validation - only for initial "
-"experimentation."
-
-msgid "Limited"
-msgstr "Limited"
-
-msgid "Tested on a small dataset. Requires manual tuning and close monitoring."
-msgstr "Tested on a small dataset. Requires manual tuning and close monitoring."
-
-msgid "Testing"
-msgstr "Testing"
-
-msgid "Prepared for more extensive testing; not yet approved for production."
-msgstr "Prepared for more extensive testing; not yet approved for production."
-
-msgid "Production"
-msgstr "Production"
-
-msgid "Approved for general use."
-msgstr "Approved for general use."
-
-msgid "Author note"
-msgstr "Author note"
-
-msgid "Selected"
-msgstr "Selected"
+msgid "Any period"
+msgstr "Any period"
 
 msgid "Select Model"
 msgstr "Select Model"
 
-msgid "Any period"
-msgstr "Any period"
-
 msgid "Search models"
 msgstr "Search models"
 
-msgid "Period"
-msgstr "Period"
-
 msgid "Clear statuses"
 msgstr "Clear statuses"
+
+msgid "Period"
+msgstr "Period"
 
 msgid "Covariates"
 msgstr "Covariates"
@@ -439,6 +430,12 @@ msgstr "Author"
 
 msgid "Unknown"
 msgstr "Unknown"
+
+msgid "Author note"
+msgstr "Author note"
+
+msgid "Selected"
+msgstr "Selected"
 
 msgid "Use this model"
 msgstr "Use this model"
@@ -1043,6 +1040,9 @@ msgstr "Model archived"
 msgid "Failed to archive model"
 msgstr "Failed to archive model"
 
+msgid "Any"
+msgstr "Any"
+
 msgid "No covariate names available"
 msgstr "No covariate names available"
 
@@ -1226,6 +1226,15 @@ msgstr "No prediction data found."
 
 msgid "Loading"
 msgstr "Loading"
+
+msgid "Suggested"
+msgstr "Suggested"
+
+msgid "Data elements"
+msgstr "Data elements"
+
+msgid "Data items"
+msgstr "Data items"
 
 msgid "Start typing to search for data items"
 msgstr "Start typing to search for data items"

--- a/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelect.module.css
+++ b/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelect.module.css
@@ -158,6 +158,15 @@
     border-block-end: none;
 }
 
+.sectionHeader {
+    padding: 0.5rem 0.75rem 0.25rem;
+    color: #4b5563;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.25;
+    text-transform: uppercase;
+}
+
 .infoSearchItem {
     padding: 0.5rem 0.75rem;
     color: #6b7280;

--- a/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelect.tsx
+++ b/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelect.tsx
@@ -18,6 +18,7 @@ interface DataItemSelectProps {
     value?: string;
     error?: string;
     dataElementsOnly?: boolean;
+    suggestedKeyword?: string;
 }
 
 export const DataItemSelect = ({
@@ -27,6 +28,7 @@ export const DataItemSelect = ({
     value,
     error,
     dataElementsOnly = false,
+    suggestedKeyword,
 }: DataItemSelectProps) => {
     const selectedId = id ?? value;
     const { dataItem: initialDataItem } = useDataItemById(selectedId);
@@ -54,6 +56,7 @@ export const DataItemSelect = ({
             initialDataItem={initialDataItem}
             initialDataItems={initialDataItems}
             initialLoading={isLoadingInitialItems}
+            suggestedKeyword={suggestedKeyword}
             onChange={onChange}
             label={label}
             value={selectedId}

--- a/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelectField.tsx
+++ b/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/DataItemSelect/DataItemSelectField.tsx
@@ -19,6 +19,7 @@ interface DataItemSelectFieldProps {
     initialDataItem?: DataItem;
     initialDataItems: DataItem[];
     initialLoading: boolean;
+    suggestedKeyword?: string;
     onChange: (id: string | null) => void;
     label?: string;
     value?: string;
@@ -30,6 +31,7 @@ export const DataItemSelectField = ({
     initialDataItem,
     initialDataItems,
     initialLoading,
+    suggestedKeyword,
     onChange,
     label,
     value,
@@ -64,9 +66,36 @@ export const DataItemSelectField = ({
     }, [initialDataItem, value]);
 
     const debouncedQuery = useDebounce(searchQuery, 300);
+    const normalizedSuggestedKeyword = suggestedKeyword?.trim();
 
     const anchorRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const { data: suggestedData, isLoading: isLoadingSuggested } = useApiDataQuery<DataItemsResponse>({
+        queryKey: [
+            'dataItems',
+            dataElementsOnly ? 'dataElements' : 'allDataItems',
+            'suggested',
+            normalizedSuggestedKeyword,
+        ],
+        enabled: !!normalizedSuggestedKeyword,
+        query: {
+            resource: 'dataItems',
+            params: {
+                filter: [
+                    `displayName:ilike:${normalizedSuggestedKeyword ?? ''}`,
+                    dataElementsOnly
+                        ? 'dimensionItemType:in:[DATA_ELEMENT]'
+                        : 'dimensionItemType:in:[PROGRAM_DATA_ELEMENT,INDICATOR,PROGRAM_INDICATOR,DATA_ELEMENT]',
+                ],
+                fields: 'id,displayName',
+                order: 'displayName:asc',
+                page: 1,
+                pageSize: 20,
+            },
+        },
+        staleTime: 5 * 60 * 1000,
+        cacheTime: 10 * 60 * 1000,
+    });
     const { data, isLoading } = useApiDataQuery<DataItemsResponse>({
         queryKey: ['dataItems', dataElementsOnly ? 'dataElements' : 'allDataItems', debouncedQuery],
         query: {
@@ -89,7 +118,10 @@ export const DataItemSelectField = ({
     });
 
     const searchResults = data?.dataItems || [];
+    const suggestedItems = suggestedData?.dataItems || [];
     const displayItems = debouncedQuery ? searchResults : initialDataItems;
+    const suggestedItemIds = new Set(suggestedItems.map(item => item.id));
+    const defaultItems = displayItems.filter(item => !suggestedItemIds.has(item.id));
 
     const handleTriggerClick = () => {
         setIsDropdownOpen(!isDropdownOpen);
@@ -128,10 +160,52 @@ export const DataItemSelectField = ({
         onChange(null);
     };
 
+    const renderOption = (option: DataItem) => (
+        <li
+            key={option.id}
+            onClick={() => handleOptionClick(option)}
+            className={styles.dropDownItem}
+        >
+            <div>{option.displayName}</div>
+        </li>
+    );
+
     const renderList = () => {
         if ((isLoading || initialLoading) && debouncedQuery) {
             return <li className={styles.infoSearchItem}>{i18n.t('Loading')}</li>;
         }
+
+        if (!debouncedQuery && normalizedSuggestedKeyword) {
+            if (
+                (isLoadingSuggested || initialLoading) &&
+                suggestedItems.length === 0 &&
+                defaultItems.length === 0
+            ) {
+                return <li className={styles.infoSearchItem}>{i18n.t('Loading')}</li>;
+            }
+
+            if (suggestedItems.length > 0 || defaultItems.length > 0) {
+                return (
+                    <>
+                        {suggestedItems.length > 0 && (
+                            <>
+                                <li className={styles.sectionHeader}>{i18n.t('Suggested')}</li>
+                                {suggestedItems.map(renderOption)}
+                            </>
+                        )}
+                        {defaultItems.length > 0 && (
+                            <>
+                                <li className={styles.sectionHeader}>
+                                    {dataElementsOnly ? i18n.t('Data elements') : i18n.t('Data items')}
+                                </li>
+                                {defaultItems.map(renderOption)}
+                            </>
+                        )}
+                    </>
+                );
+            }
+        }
+
         if (displayItems.length === 0 && searchQuery.length === 0) {
             return (
                 <li className={styles.infoSearchItem}>
@@ -145,15 +219,7 @@ export const DataItemSelectField = ({
 
         return (
             <>
-                {displayItems.map(option => (
-                    <li
-                        key={option.id}
-                        onClick={() => handleOptionClick(option)}
-                        className={styles.dropDownItem}
-                    >
-                        <div>{option.displayName}</div>
-                    </li>
-                ))}
+                {displayItems.map(renderOption)}
             </>
         );
     };

--- a/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/QuantileMappingForm.tsx
+++ b/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/QuantileMappingForm.tsx
@@ -81,6 +81,14 @@ const quantileMappingFields = [
     'quantile_mid_high',
 ] as const satisfies MappingField[];
 
+const quantileSuggestedKeywords: Record<typeof quantileMappingFields[number], string> = {
+    quantile_high: 'high',
+    quantile_mid_high: 'mid high',
+    median: 'median',
+    quantile_mid_low: 'mid low',
+    quantile_low: 'low',
+};
+
 export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -242,30 +250,40 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         value={quantile_high}
                         onChange={id => updateQuantile('quantile_high', id)}
                         error={errors.quantile_high?.message}
+                        dataElementsOnly
+                        suggestedKeyword={quantileSuggestedKeywords.quantile_high}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile mid high')}
                         value={quantile_mid_high}
                         onChange={id => updateQuantile('quantile_mid_high', id)}
                         error={errors.quantile_mid_high?.message}
+                        dataElementsOnly
+                        suggestedKeyword={quantileSuggestedKeywords.quantile_mid_high}
                     />
                     <DataItemSelect
                         label={i18n.t('Median')}
                         value={median}
                         onChange={id => updateQuantile('median', id)}
                         error={errors.median?.message}
+                        dataElementsOnly
+                        suggestedKeyword={quantileSuggestedKeywords.median}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile mid low')}
                         value={quantile_mid_low}
                         onChange={id => updateQuantile('quantile_mid_low', id)}
                         error={errors.quantile_mid_low?.message}
+                        dataElementsOnly
+                        suggestedKeyword={quantileSuggestedKeywords.quantile_mid_low}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile low')}
                         value={quantile_low}
                         onChange={id => updateQuantile('quantile_low', id)}
                         error={errors.quantile_low?.message}
+                        dataElementsOnly
+                        suggestedKeyword={quantileSuggestedKeywords.quantile_low}
                     />
 
                     <div className={styles.alertOutput}>

--- a/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/QuantileMappingForm.tsx
+++ b/apps/modeling-app/src/components/PageContent/PredictionImport/QuantileMappingForm/QuantileMappingForm.tsx
@@ -30,7 +30,10 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { usePredictionSeries } from '../../PredictionDetails/hooks/usePredictionSeries';
 import { PredictionAlertsDialog } from '../../PredictionAlerts';
 import { usePredictionSetup } from '@/hooks/usePredictionSetup';
-import { getPredictionSetupQuantileTargets } from '@/utils/predictionSetupImportMapping';
+import {
+    getPredictionSetupQuantileTargets,
+    QUANTILE_SUGGESTED_KEYWORDS,
+} from '@/utils/predictionSetupImportMapping';
 
 type Props = {
     prediction: PredictionInfo;
@@ -80,14 +83,6 @@ const quantileMappingFields = [
     'quantile_mid_low',
     'quantile_mid_high',
 ] as const satisfies MappingField[];
-
-const quantileSuggestedKeywords: Record<typeof quantileMappingFields[number], string> = {
-    quantile_high: 'high',
-    quantile_mid_high: 'mid high',
-    median: 'median',
-    quantile_mid_low: 'mid low',
-    quantile_low: 'low',
-};
 
 export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Props) => {
     const navigate = useNavigate();
@@ -251,7 +246,7 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         onChange={id => updateQuantile('quantile_high', id)}
                         error={errors.quantile_high?.message}
                         dataElementsOnly
-                        suggestedKeyword={quantileSuggestedKeywords.quantile_high}
+                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS.quantile_high}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile mid high')}
@@ -259,7 +254,7 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         onChange={id => updateQuantile('quantile_mid_high', id)}
                         error={errors.quantile_mid_high?.message}
                         dataElementsOnly
-                        suggestedKeyword={quantileSuggestedKeywords.quantile_mid_high}
+                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS.quantile_mid_high}
                     />
                     <DataItemSelect
                         label={i18n.t('Median')}
@@ -267,7 +262,7 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         onChange={id => updateQuantile('median', id)}
                         error={errors.median?.message}
                         dataElementsOnly
-                        suggestedKeyword={quantileSuggestedKeywords.median}
+                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS.median}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile mid low')}
@@ -275,7 +270,7 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         onChange={id => updateQuantile('quantile_mid_low', id)}
                         error={errors.quantile_mid_low?.message}
                         dataElementsOnly
-                        suggestedKeyword={quantileSuggestedKeywords.quantile_mid_low}
+                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS.quantile_mid_low}
                     />
                     <DataItemSelect
                         label={i18n.t('Quantile low')}
@@ -283,7 +278,7 @@ export const QuantileMappingForm = ({ prediction, model, predictionSetupId }: Pr
                         onChange={id => updateQuantile('quantile_low', id)}
                         error={errors.quantile_low?.message}
                         dataElementsOnly
-                        suggestedKeyword={quantileSuggestedKeywords.quantile_low}
+                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS.quantile_low}
                     />
 
                     <div className={styles.alertOutput}>

--- a/apps/modeling-app/src/components/PredictionSetup/MarkReadyForForecastingModal/MarkReadyForForecastingModal.tsx
+++ b/apps/modeling-app/src/components/PredictionSetup/MarkReadyForForecastingModal/MarkReadyForForecastingModal.tsx
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import { DataItemSelect } from '../../PageContent/PredictionImport/QuantileMappingForm/DataItemSelect';
 import {
     QUANTILE_KEYS,
+    QUANTILE_SUGGESTED_KEYWORDS,
     type PredictionSetupFormValues,
 } from '@/utils/predictionSetupImportMapping';
 import styles from './MarkReadyForForecastingModal.module.css';
@@ -196,6 +197,7 @@ export const MarkReadyForForecastingModal = ({
                                                         onChange={field.onChange}
                                                         error={errors[name]?.message}
                                                         dataElementsOnly
+                                                        suggestedKeyword={QUANTILE_SUGGESTED_KEYWORDS[name]}
                                                     />
                                                 )}
                                             />

--- a/apps/modeling-app/src/utils/predictionSetupImportMapping.ts
+++ b/apps/modeling-app/src/utils/predictionSetupImportMapping.ts
@@ -10,6 +10,14 @@ export const QUANTILE_KEYS = [
 
 export type QuantileKey = typeof QUANTILE_KEYS[number];
 
+export const QUANTILE_SUGGESTED_KEYWORDS: Record<QuantileKey, string> = {
+    quantile_high: 'high',
+    quantile_mid_high: 'mid high',
+    median: 'median',
+    quantile_mid_low: 'mid low',
+    quantile_low: 'low',
+};
+
 export type PredictionSetupFormValues = {
     name: string;
     use_import_mapping: boolean;


### PR DESCRIPTION
## Summary
- Reuse the quantile suggestion keywords from a shared prediction setup mapping utility.
- Show suggested DHIS2 data elements in the default import mapping controls for prediction setup create and edit.
- Keep the prediction import mapping flow aligned with the shared keyword map and include the generated i18n template updates.

## Validation
- `pnpm --filter @dhis2-chap/modeling-app tsc:check`
- `pnpm test apps/modeling-app/src/utils/predictionSetupImportMapping.test.ts`
- `pnpm --filter @dhis2-chap/modeling-app linter:check`