### PR TITLE
ci: update stable chap core ref

### DIFF
--- a/.github/workflows/e2e-stable.yml
+++ b/.github/workflows/e2e-stable.yml
@@ -13,7 +13,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    CHAP_CORE_STABLE_REF: v1.3.0
+    CHAP_CORE_STABLE_REF: v2.0.0
 
 jobs:
     e2e-stable:


### PR DESCRIPTION
## Summary

- updates the e2e-stable workflow to build CHAP core from v2.0.0 instead of v1.3.0
- keeps the workflow name and trigger behavior unchanged

## Why

PR #205 failed e2e-stable run 27169737240 while POSTing /v1/crud/prediction-setups, returning 404 from CHAP core v1.3.0. I checked the newer chap-core tags: v1.4.0 still does not contain the prediction setup routes, while v2.0.0 does include /v1/crud/prediction-setups and /v1/crud/prediction-setups/{predictionSetupId}/run.

## Validation

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-stable.yml"); puts "yaml ok"'
- git diff --check
- pnpm linter:check