### PR TITLE
fix: support query aliases on older DHIS2 versions

### DIFF
--- a/.changeset/support-old-query-aliases.md
+++ b/.changeset/support-old-query-aliases.md
@@ -1,0 +1,5 @@
+---
+'@dhis2-chap/modeling-app': patch
+---
+
+Use query aliases for long evaluation data requests on older DHIS2 versions.

--- a/apps/modeling-app/src/components/ModelExecutionForm/utils/prepareBacktestData.ts
+++ b/apps/modeling-app/src/components/ModelExecutionForm/utils/prepareBacktestData.ts
@@ -4,7 +4,7 @@ import { ModelExecutionFormValues } from '../hooks/useModelExecutionFormState';
 import { getPeriodsInRange, PERIOD_TYPES, toDhis2FixedPeriodType } from '@dhis2-chap/core';
 import { DataSource, ModelSpecRead, ObservationBase } from '@dhis2-chap/ui';
 import { useDataEngine } from '@dhis2/app-runtime';
-import { AnalyticsResponse, OrgUnitResponse, fetchAnalytics, ORG_UNITS_QUERY } from './queryUtils';
+import { AnalyticsResponse, OrgUnitResponse, fetchAnalytics, fetchOrgUnits } from './queryUtils';
 import { generateBacktestDataHash } from './hashUtils';
 import { type Dhis2PeriodSettings } from '@/hooks/useDhis2PeriodSettings';
 
@@ -93,9 +93,10 @@ export const prepareBacktestData = async (
 
     const cachedOrgUnitResponse = queryClient.getQueryData(['new-backtest-data', 'org-units', hash]) as OrgUnitResponse | undefined;
 
-    const orgUnitResponse = cachedOrgUnitResponse || await dataEngine.query(
-        ORG_UNITS_QUERY(orgUnitIds),
-    ) as OrgUnitResponse;
+    const orgUnitResponse = cachedOrgUnitResponse || await fetchOrgUnits(
+        orgUnitIds,
+        dataEngine,
+    );
 
     if (!cachedOrgUnitResponse) {
         queryClient.setQueryData(['new-backtest-data', 'org-units', hash], orgUnitResponse);

--- a/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
+++ b/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
@@ -1,4 +1,5 @@
 import { useDataEngine } from '@dhis2/app-runtime';
+import { queryViaAlias } from '@/utils/queryAlias';
 
 export type AnalyticsResponse = {
     response: {
@@ -53,27 +54,9 @@ const fetchAnalyticsViaAlias = async (
     dataEngine: ReturnType<typeof useDataEngine>,
 ): Promise<AnalyticsResponse> => {
     const target = buildAnalyticsTargetPath(dataElements, periods, orgUnits);
-
-    const aliasResult = await dataEngine.mutate({
-        resource: 'query/alias',
-        type: 'create' as const,
-        data: { target },
-    });
-
-    const alias = aliasResult as Record<string, unknown>;
-    const aliasId = alias.id as string | undefined;
-
-    if (!aliasId) {
-        throw new Error('Failed to create query alias: no id in response');
-    }
-
-    const analyticsResponse = await dataEngine.query({
-        response: {
-            resource: `query/alias/${aliasId}`,
-        },
-    });
-
-    return analyticsResponse as AnalyticsResponse;
+    return {
+        response: await queryViaAlias<AnalyticsResponse['response']>(dataEngine, target),
+    };
 };
 
 export const fetchAnalytics = async (
@@ -108,3 +91,41 @@ export const ORG_UNITS_QUERY = (orgUnitIds: string[]) => ({
         },
     },
 });
+
+const buildOrgUnitsTargetPath = (orgUnitIds: string[]): string => {
+    const params = new URLSearchParams({
+        filter: `id:in:[${orgUnitIds.join(',')}]`,
+        fields: 'id,geometry,parent[id],level,displayName,code',
+        paging: 'false',
+    });
+
+    return `/api/organisationUnits?${params.toString()}`;
+};
+
+const fetchOrgUnitsViaAlias = async (
+    orgUnitIds: string[],
+    dataEngine: ReturnType<typeof useDataEngine>,
+): Promise<OrgUnitResponse> => {
+    const target = buildOrgUnitsTargetPath(orgUnitIds);
+    return {
+        geojson: await queryViaAlias<OrgUnitResponse['geojson']>(dataEngine, target),
+    };
+};
+
+export const fetchOrgUnits = async (
+    orgUnitIds: string[],
+    dataEngine: ReturnType<typeof useDataEngine>,
+): Promise<OrgUnitResponse> => {
+    try {
+        return await fetchOrgUnitsViaAlias(orgUnitIds, dataEngine);
+    } catch (error) {
+        console.warn(
+            'Query alias creation failed, falling back to direct organisation unit query.',
+            'This may fail for large queries that exceed URL length limits.',
+            error,
+        );
+        return await dataEngine.query(
+            ORG_UNITS_QUERY(orgUnitIds),
+        ) as OrgUnitResponse;
+    }
+};

--- a/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
+++ b/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
@@ -1,5 +1,5 @@
 import { useDataEngine } from '@dhis2/app-runtime';
-import { queryViaAlias } from '@/utils/queryAlias';
+import { queryWithAliasFallback } from '@/utils/queryAlias';
 
 export type AnalyticsResponse = {
     response: {
@@ -28,104 +28,31 @@ export type OrgUnitResponse = {
     };
 };
 
-export const ANALYTICS_QUERY = (dataElements: string[], periods: string[], orgUnits: string[]) => ({
-    response: {
-        resource: 'analytics',
-        params: {
-            paging: false,
-            dimension: `dx:${dataElements.join(';')},ou:${orgUnits.join(';')},pe:${periods.join(';')}`,
-        },
-    },
-});
-
-const buildAnalyticsTargetPath = (
-    dataElements: string[],
-    periods: string[],
-    orgUnits: string[],
-): string => {
-    const dimension = `dx:${dataElements.join(';')},ou:${orgUnits.join(';')},pe:${periods.join(';')}`;
-    return `/api/analytics?paging=false&dimension=${dimension}`;
-};
-
-const fetchAnalyticsViaAlias = async (
-    dataElements: string[],
-    periods: string[],
-    orgUnits: string[],
-    dataEngine: ReturnType<typeof useDataEngine>,
-): Promise<AnalyticsResponse> => {
-    const target = buildAnalyticsTargetPath(dataElements, periods, orgUnits);
-    return {
-        response: await queryViaAlias<AnalyticsResponse['response']>(dataEngine, target),
-    };
-};
-
 export const fetchAnalytics = async (
     dataElements: string[],
     periods: string[],
     orgUnits: string[],
     dataEngine: ReturnType<typeof useDataEngine>,
-): Promise<AnalyticsResponse> => {
-    try {
-        return await fetchAnalyticsViaAlias(
-            dataElements, periods, orgUnits, dataEngine,
-        );
-    } catch (error) {
-        console.warn(
-            'Query alias creation failed, falling back to direct analytics query.',
-            'This may fail for large queries that exceed URL length limits.',
-            error,
-        );
-        return await dataEngine.query(
-            ANALYTICS_QUERY(dataElements, periods, orgUnits),
-        ) as AnalyticsResponse;
-    }
-};
+): Promise<AnalyticsResponse> => ({
+    response: await queryWithAliasFallback<AnalyticsResponse['response']>(dataEngine, {
+        resource: 'analytics',
+        params: {
+            paging: false,
+            dimension: `dx:${dataElements.join(';')},ou:${orgUnits.join(';')},pe:${periods.join(';')}`,
+        },
+    }),
+});
 
-export const ORG_UNITS_QUERY = (orgUnitIds: string[]) => ({
-    geojson: {
+export const fetchOrgUnits = async (
+    orgUnitIds: string[],
+    dataEngine: ReturnType<typeof useDataEngine>,
+): Promise<OrgUnitResponse> => ({
+    geojson: await queryWithAliasFallback<OrgUnitResponse['geojson']>(dataEngine, {
         resource: 'organisationUnits',
         params: {
             filter: `id:in:[${orgUnitIds.join(',')}]`,
             fields: 'id,geometry,parent[id],level,displayName,code',
             paging: false,
         },
-    },
+    }),
 });
-
-const buildOrgUnitsTargetPath = (orgUnitIds: string[]): string => {
-    const params = new URLSearchParams({
-        filter: `id:in:[${orgUnitIds.join(',')}]`,
-        fields: 'id,geometry,parent[id],level,displayName,code',
-        paging: 'false',
-    });
-
-    return `/api/organisationUnits?${params.toString()}`;
-};
-
-const fetchOrgUnitsViaAlias = async (
-    orgUnitIds: string[],
-    dataEngine: ReturnType<typeof useDataEngine>,
-): Promise<OrgUnitResponse> => {
-    const target = buildOrgUnitsTargetPath(orgUnitIds);
-    return {
-        geojson: await queryViaAlias<OrgUnitResponse['geojson']>(dataEngine, target),
-    };
-};
-
-export const fetchOrgUnits = async (
-    orgUnitIds: string[],
-    dataEngine: ReturnType<typeof useDataEngine>,
-): Promise<OrgUnitResponse> => {
-    try {
-        return await fetchOrgUnitsViaAlias(orgUnitIds, dataEngine);
-    } catch (error) {
-        console.warn(
-            'Query alias creation failed, falling back to direct organisation unit query.',
-            'This may fail for large queries that exceed URL length limits.',
-            error,
-        );
-        return await dataEngine.query(
-            ORG_UNITS_QUERY(orgUnitIds),
-        ) as OrgUnitResponse;
-    }
-};

--- a/apps/modeling-app/src/utils/queryAlias.ts
+++ b/apps/modeling-app/src/utils/queryAlias.ts
@@ -2,7 +2,19 @@ import { useDataEngine } from '@dhis2/app-runtime';
 
 type DataEngine = ReturnType<typeof useDataEngine>;
 
-export const createQueryAlias = async (
+export type ResourceQuery = {
+    resource: string;
+    params: Record<string, string | number | boolean>;
+};
+
+const buildTargetPath = ({ resource, params }: ResourceQuery): string => {
+    const search = new URLSearchParams(
+        Object.entries(params).map(([key, value]) => [key, String(value)]),
+    );
+    return `/api/${resource}?${search.toString()}`;
+};
+
+const createQueryAlias = async (
     dataEngine: DataEngine,
     target: string,
 ): Promise<string> => {
@@ -14,8 +26,7 @@ export const createQueryAlias = async (
         data: { target },
     });
 
-    const alias = aliasResult as Record<string, unknown>;
-    const aliasId = alias.id as string | undefined;
+    const aliasId = (aliasResult as { id?: string }).id;
 
     if (!aliasId) {
         throw new Error('Failed to create query alias: no id in response');
@@ -24,7 +35,7 @@ export const createQueryAlias = async (
     return aliasId;
 };
 
-export const queryViaAlias = async <T>(
+const queryViaAlias = async <T>(
     dataEngine: DataEngine,
     target: string,
 ): Promise<T> => {
@@ -37,4 +48,21 @@ export const queryViaAlias = async <T>(
     });
 
     return (response as { response: T }).response;
+};
+
+export const queryWithAliasFallback = async <T>(
+    dataEngine: DataEngine,
+    query: ResourceQuery,
+): Promise<T> => {
+    try {
+        return await queryViaAlias<T>(dataEngine, buildTargetPath(query));
+    } catch (error) {
+        console.warn(
+            `Query alias request for ${query.resource} failed, falling back to a direct query.`,
+            'This may fail for large queries that exceed URL length limits.',
+            error,
+        );
+        const response = await dataEngine.query({ response: query });
+        return (response as { response: T }).response;
+    }
 };

--- a/apps/modeling-app/src/utils/queryAlias.ts
+++ b/apps/modeling-app/src/utils/queryAlias.ts
@@ -1,0 +1,40 @@
+import { useDataEngine } from '@dhis2/app-runtime';
+
+type DataEngine = ReturnType<typeof useDataEngine>;
+
+export const createQueryAlias = async (
+    dataEngine: DataEngine,
+    target: string,
+): Promise<string> => {
+    const aliasResult = await dataEngine.mutate({
+        // Query aliases are unversioned in DHIS2 2.42; escape the app-runtime
+        // version prefix so older instances resolve /api/query/alias.
+        resource: '../query/alias',
+        type: 'create' as const,
+        data: { target },
+    });
+
+    const alias = aliasResult as Record<string, unknown>;
+    const aliasId = alias.id as string | undefined;
+
+    if (!aliasId) {
+        throw new Error('Failed to create query alias: no id in response');
+    }
+
+    return aliasId;
+};
+
+export const queryViaAlias = async <T>(
+    dataEngine: DataEngine,
+    target: string,
+): Promise<T> => {
+    const aliasId = await createQueryAlias(dataEngine, target);
+    const response = await dataEngine.query({
+        response: {
+            // See createQueryAlias for why this intentionally uses ../.
+            resource: `../query/alias/${aliasId}`,
+        },
+    });
+
+    return (response as { response: T }).response;
+};


### PR DESCRIPTION
## Summary
- centralize query alias requests through the unversioned /api/query/alias endpoint so DHIS2 2.42 instances work
- use query aliases for evaluation analytics and organisation-unit metadata requests that can exceed URL length limits
- keep saved dataset CSV downloads direct, since those URLs are short route-api calls by dataset id

## Root cause
DHIS2 2.42 exposes query aliases at /api/query/alias, but the app runtime prefixes resources with the API version. That makes query/alias resolve to /api/42/query/alias, which returns 404 on older instances. The compatibility helper escapes the version prefix with ../query/alias.

## Validation
- pnpm --filter @dhis2-chap/modeling-app tsc:check
- pnpm --filter @dhis2-chap/modeling-app linter:check
- git diff --check