### PR TITLE
feat: add read-only scheduling widget to predictions setup [CLIM-751]

### DIFF
--- a/.changeset/scheduling-status-widget.md
+++ b/.changeset/scheduling-status-widget.md
@@ -1,0 +1,5 @@
+---
+'@dhis2-chap/modeling-app': minor
+---
+
+Add an experimental scheduling status widget to the prediction setup dashboard.

--- a/apps/modeling-app/i18n/en.pot
+++ b/apps/modeling-app/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-09T06:54:57.697Z\n"
-"PO-Revision-Date: 2026-06-09T06:54:57.709Z\n"
+"POT-Creation-Date: 2026-06-09T11:28:01.084Z\n"
+"PO-Revision-Date: 2026-06-09T11:28:01.084Z\n"
 
 msgid "Create new..."
 msgstr "Create new..."
@@ -839,6 +839,18 @@ msgstr "Prediction setup updated"
 msgid "Failed to update prediction setup"
 msgstr "Failed to update prediction setup"
 
+msgid "Scheduling"
+msgstr "Scheduling"
+
+msgid "No prediction setup found"
+msgstr "No prediction setup found"
+
+msgid "Enabled"
+msgstr "Enabled"
+
+msgid "Disabled"
+msgstr "Disabled"
+
 msgid "{{count}} {{label}}"
 msgid_plural "{{count}} {{label}}"
 msgstr[0] "{{count}} {{label}}"
@@ -846,9 +858,6 @@ msgstr[1] "{{count}} {{label}}"
 
 msgid "Configuration"
 msgstr "Configuration"
-
-msgid "No prediction setup found"
-msgstr "No prediction setup found"
 
 msgid "location"
 msgstr "location"
@@ -1387,6 +1396,18 @@ msgstr "Search for data elements"
 msgid "Search for indicators, data elements, or program indicators"
 msgstr "Search for indicators, data elements, or program indicators"
 
+msgid "Checking import with DHIS2"
+msgstr "Checking import with DHIS2"
+
+msgid "Checking values to clear"
+msgstr "Checking values to clear"
+
+msgid "Clearing previous values"
+msgstr "Clearing previous values"
+
+msgid "Importing prediction values"
+msgstr "Importing prediction values"
+
 msgid "Clear and import"
 msgstr "Clear and import"
 
@@ -1409,6 +1430,9 @@ msgstr "Clear and import prediction"
 
 msgid "Import prediction"
 msgstr "Import prediction"
+
+msgid "Import progress"
+msgstr "Import progress"
 
 msgid "Quantile high"
 msgstr "Quantile high"
@@ -1815,6 +1839,9 @@ msgstr "Show metric visualization plots in the evaluation dashboard"
 
 msgid "Show evaluation visualization plots in the evaluation dashboard"
 msgstr "Show evaluation visualization plots in the evaluation dashboard"
+
+msgid "Show scheduling information in the prediction setup dashboard"
+msgstr "Show scheduling information in the prediction setup dashboard"
 
 msgid "Settings saved successfully"
 msgstr "Settings saved successfully"

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ConfiguredModelDashboard.tsx
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ConfiguredModelDashboard.tsx
@@ -3,9 +3,11 @@ import { useParams } from 'react-router-dom';
 import { sortByCreatedDesc } from '../../../utils/sortByCreated';
 import { JOB_STATUSES, useJobs } from '../../../hooks/useJobs';
 import { usePredictionSetup } from '../../../hooks/usePredictionSetup';
+import { FEATURES, useExperimentalFeature } from '../../../features/settings/Experimental';
 import { ActivityWidget } from './ActivityWidget';
 import { PredictionRunsWidget } from './PredictionRunsWidget';
 import { QuickActionsWidget } from './QuickActionsWidget';
+import { SchedulingWidget } from './SchedulingWidget';
 import { SummaryWidget } from './SummaryWidget';
 import styles from './ConfiguredModelDashboard.module.css';
 
@@ -18,6 +20,7 @@ export const ConfiguredModelDashboard: React.FC = () => {
         hasValidPredictionSetupId,
         isLoading,
     } = usePredictionSetup(predictionSetupId);
+    const { enabled: isSchedulingEnabled } = useExperimentalFeature(FEATURES.SCHEDULING);
     const {
         jobs = [],
         error: jobsError,
@@ -63,6 +66,12 @@ export const ConfiguredModelDashboard: React.FC = () => {
                     isLoading={isLoading}
                     latestPredictionId={predictions[0]?.id}
                 />
+                {isSchedulingEnabled && (
+                    <SchedulingWidget
+                        predictionSetup={predictionSetup}
+                        isLoading={isLoading}
+                    />
+                )}
                 <SummaryWidget
                     predictionSetup={predictionSetup}
                     isLoading={isLoading}

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/SchedulingWidget.module.css
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/SchedulingWidget.module.css
@@ -1,0 +1,58 @@
+.content {
+    padding: 16px;
+    padding-block-start: 8px;
+}
+
+.row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.label {
+    color: var(--colors-grey700);
+    font-size: 13px;
+    line-height: 18px;
+}
+
+.enabledValue,
+.disabledValue {
+    color: var(--colors-grey900);
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+}
+
+.enabledValue::before,
+.disabledValue::before {
+    content: "";
+    display: inline-block;
+    inline-size: 8px;
+    block-size: 8px;
+    margin-inline-end: 8px;
+    border-radius: 50%;
+    vertical-align: 1px;
+}
+
+.enabledValue::before {
+    background: var(--colors-green600);
+}
+
+.disabledValue::before {
+    background: var(--colors-grey500);
+}
+
+.loadingState,
+.emptyState {
+    padding: 18px;
+    color: var(--colors-grey700);
+    font-size: inherit;
+    line-height: 20px;
+}
+
+.loadingState {
+    display: flex;
+    min-block-size: 72px;
+    align-items: center;
+    justify-content: center;
+}

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/SchedulingWidget.tsx
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/SchedulingWidget.tsx
@@ -1,0 +1,48 @@
+import i18n from '@dhis2/d2-i18n';
+import { CircularLoader } from '@dhis2/ui';
+import type { PredictionSetupReadWithPredictions } from '@dhis2-chap/ui';
+import { Widget } from '@dhis2-chap/ui';
+import styles from './SchedulingWidget.module.css';
+
+type Props = {
+    predictionSetup?: PredictionSetupReadWithPredictions;
+    isLoading: boolean;
+};
+
+export const SchedulingWidget = ({
+    predictionSetup,
+    isLoading,
+}: Props) => {
+    const isScheduled = predictionSetup?.scheduleEnabled ?? false;
+
+    return (
+        <Widget
+            header={i18n.t('Scheduling')}
+            noncollapsible
+        >
+            {isLoading && (
+                <div className={styles.loadingState}>
+                    <CircularLoader small />
+                </div>
+            )}
+            {!isLoading && !predictionSetup && (
+                <div className={styles.emptyState}>
+                    {i18n.t('No prediction setup found')}
+                </div>
+            )}
+            {!isLoading && predictionSetup && (
+                <div className={styles.content}>
+                    <div className={styles.row}>
+                        <span className={styles.label}>{i18n.t('Status')}</span>
+                        <span
+                            className={isScheduled ? styles.enabledValue : styles.disabledValue}
+                            data-test="scheduling-status"
+                        >
+                            {isScheduled ? i18n.t('Enabled') : i18n.t('Disabled')}
+                        </span>
+                    </div>
+                </div>
+            )}
+        </Widget>
+    );
+};

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/index.ts
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/SchedulingWidget/index.ts
@@ -1,0 +1,1 @@
+export { SchedulingWidget } from './SchedulingWidget';

--- a/apps/modeling-app/src/features/settings/Experimental/ExperimentalSettings.tsx
+++ b/apps/modeling-app/src/features/settings/Experimental/ExperimentalSettings.tsx
@@ -69,6 +69,13 @@ export const ExperimentalSettings = () => {
                                     onChange={() => toggleFeature(FEATURES.EVALUATION_PLOTS)}
                                     disabled={isSaving}
                                 />
+                                <ChoiceCard
+                                    title={i18n.t('Scheduling')}
+                                    description={i18n.t('Show scheduling information in the prediction setup dashboard')}
+                                    checked={settings.features[FEATURES.SCHEDULING] ?? false}
+                                    onChange={() => toggleFeature(FEATURES.SCHEDULING)}
+                                    disabled={isSaving}
+                                />
                             </div>
                         </div>
                     )}

--- a/apps/modeling-app/src/features/settings/Experimental/hooks/useExperimentalSettings.ts
+++ b/apps/modeling-app/src/features/settings/Experimental/hooks/useExperimentalSettings.ts
@@ -24,6 +24,7 @@ export const DATASTORE_RESOURCE = 'dataStore/modeling/experimental';
 export const FEATURES = {
     METRIC_PLOTS: 'metricPlots',
     EVALUATION_PLOTS: 'evaluationPlots',
+    SCHEDULING: 'scheduling',
 } as const;
 
 export type FeatureKey = typeof FEATURES[keyof typeof FEATURES];


### PR DESCRIPTION
## Summary

Adds the experimental `scheduling` feature flag and a gated Scheduling widget on the prediction setup dashboard. The widget appears after Quick actions and displays the core `scheduleEnabled` value as Enabled or Disabled.

## Validation

- `pnpm --filter @dhis2-chap/modeling-app tsc:check`
- `pnpm --filter @dhis2-chap/modeling-app linter:check`
- `pnpm --filter @dhis2-chap/modeling-app build`
- Verified in the app against DHIS2 on `localhost:8080` that the widget is hidden while the flag is off and appears after Quick actions when enabled.
