### PR TITLE
fix: prevent stale cached analytics responses from emptying evaluation data

### DIFF
--- a/.changeset/bust-analytics-browser-cache.md
+++ b/.changeset/bust-analytics-browser-cache.md
@@ -1,0 +1,5 @@
+---
+'@dhis2-chap/modeling-app': patch
+---
+
+Prevent stale browser-cached analytics responses from producing empty evaluation data.

--- a/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
+++ b/apps/modeling-app/src/components/ModelExecutionForm/utils/queryUtils.ts
@@ -39,6 +39,7 @@ export const fetchAnalytics = async (
         params: {
             paging: false,
             dimension: `dx:${dataElements.join(';')},ou:${orgUnits.join(';')},pe:${periods.join(';')}`,
+            cacheBust: Date.now(),
         },
     }),
 });
@@ -53,6 +54,7 @@ export const fetchOrgUnits = async (
             filter: `id:in:[${orgUnitIds.join(',')}]`,
             fields: 'id,geometry,parent[id],level,displayName,code',
             paging: false,
+            cacheBust: Date.now(),
         },
     }),
 });

--- a/apps/modeling-app/src/components/NewEvaluationForm/hooks/useCreateNewBacktest.ts
+++ b/apps/modeling-app/src/components/NewEvaluationForm/hooks/useCreateNewBacktest.ts
@@ -77,6 +77,7 @@ export const useCreateNewBacktest = ({
         onMutate: () => {
             setImportSummary(null);
             setSummaryModalOpen(false);
+            queryClient.removeQueries({ queryKey: ['new-backtest-data'] });
         },
         mutationFn: async (formData: ModelExecutionFormValues) => {
             const { backtestRequest, hash } = await buildBacktestRequest(formData);
@@ -136,7 +137,7 @@ export const useCreateNewBacktest = ({
         onSuccess: (data: ImportSummaryCorrected) => {
             if (data.id) {
                 queryClient.invalidateQueries({ queryKey: ['jobs'] });
-                queryClient.invalidateQueries({ queryKey: ['new-backtest-data'] });
+                queryClient.removeQueries({ queryKey: ['new-backtest-data'] });
                 onSuccess?.();
                 navigate('/jobs');
             }


### PR DESCRIPTION
## Summary

Creating an evaluation could send an empty `providedData` array even though the data was visible in the Inspect Dataset dialog.

### Root cause

The backtest payload is built from an analytics request routed through the DHIS2 query-alias API. The alias id is a deterministic hash of the target URL, and DHIS2 serves the alias response with `Cache-Control: public, max-age=3600`. So once a request was made while the instance had no data (or analytics tables had not been run), the browser HTTP cache replayed the empty `rows: []` result for the same form selections for up to an hour — surviving page reloads. The Inspect Dataset dialog was unaffected because the Data Visualizer plugin issues a differently-parameterized request with its own cache entry.

A second, in-session layer compounded this: `prepareBacktestData` caches the analytics/org-unit responses in React Query under a content-derived hash, and the entries were cleared with `invalidateQueries`, which `getQueryData` ignores.

### Changes

- Add a `cacheBust` timestamp param to the analytics and organisation-unit requests so the alias target (and the direct fallback URL) is unique per request, bypassing the browser HTTP cache.
- Drop the cached `['new-backtest-data']` entries at the start of every dry run, so validation always reflects current DHIS2 data while a subsequent create still reuses the data the dry run validated.
- Use `removeQueries` instead of `invalidateQueries` after successful creation, since these entries are read via `getQueryData`, which ignores invalidation marks.

## Validation

- Reproduced the caching behavior against a local DHIS2 2.43 instance: identical alias targets return identical alias ids, responses carry `Cache-Control: max-age=3600, public`, and the analytics endpoint tolerates the extra param (returns rows, distinct alias id per value).
- `pnpm --filter @dhis2-chap/modeling-app tsc:check`
- `pnpm --filter @dhis2-chap/modeling-app linter:check`