### PR TITLE
feat: show active jobs in recent activity [CLIM-777]

### DIFF
--- a/.changeset/active-jobs-recent-activity.md
+++ b/.changeset/active-jobs-recent-activity.md
@@ -2,4 +2,4 @@
 "@dhis2-chap/modeling-app": patch
 ---
 
-Show active prediction setup jobs in the recent activity widget.
+Show active prediction setup jobs in the recent activity widget and open the widget by default.

--- a/.changeset/active-jobs-recent-activity.md
+++ b/.changeset/active-jobs-recent-activity.md
@@ -1,0 +1,5 @@
+---
+"@dhis2-chap/modeling-app": patch
+---
+
+Show active prediction setup jobs in the recent activity widget.

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.tsx
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.tsx
@@ -354,7 +354,7 @@ export const ActivityWidget = ({
     jobs,
     predictionSetupId,
 }: Props) => {
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(true);
     const [activityView, setActivityView] = useState<ActivityView>('chart');
     const [selectedPeriod, setSelectedPeriod] = usePersistedActivityPeriod();
     const [statusFilter, setStatusFilter] = useState<string | undefined>();

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.tsx
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.tsx
@@ -34,15 +34,19 @@ import { JobActionsMenu } from '../../../JobsTable/JobActionsMenu/JobActionsMenu
 import { StatusCell } from '../../../JobsTable/TableCells/StatusCell';
 import {
     hasDateRangeValue,
-    isJobInDateRange,
     type DateRangeValue,
 } from '../../../../utils/jobDateRange';
-import { buildJobActivityDays, type JobActivityDay } from './ActivityWidget.utils';
+import {
+    buildJobActivityDays,
+    isJobInActivityDateRange,
+    type JobActivityDay,
+} from './ActivityWidget.utils';
 import styles from './ActivityWidget.module.css';
 
 const EMPTY_VALUE = '-';
 const MAX_VISIBLE_ROWS = 5;
 const STORAGE_KEY = 'chap-modeling-app:prediction-activity-period';
+const ACTIVE_COLOR = '#f59e0b';
 const SUCCESS_COLOR = '#147cd7';
 const FAILED_COLOR = '#d32f2f';
 const columnHelper = createColumnHelper<JobDescription>();
@@ -257,6 +261,7 @@ const getChartOptions = (
             }
 
             const rows = [
+                `<span style="color:${ACTIVE_COLOR}">●</span> ${i18n.t('Active')}: <strong>${formatJobCount(day.activeCount)}</strong><br/>`,
                 `<span style="color:${SUCCESS_COLOR}">●</span> ${i18n.t('Success')}: <strong>${formatJobCount(day.successCount)}</strong><br/>`,
                 `<span style="color:${FAILED_COLOR}">●</span> ${i18n.t('Failed')}: <strong>${formatJobCount(day.failedCount)}</strong><br/>`,
             ];
@@ -289,6 +294,12 @@ const getChartOptions = (
         },
     },
     series: [
+        {
+            type: 'column',
+            name: i18n.t('Active'),
+            color: ACTIVE_COLOR,
+            data: days.map(day => day.activeCount),
+        },
         {
             type: 'column',
             name: i18n.t('Success'),
@@ -416,7 +427,7 @@ export const ActivityWidget = ({
         columnHelper.accessor('start_time', {
             header: () => i18n.t('Started'),
             filterFn: (row, _columnId, filterValue) => (
-                isJobInDateRange(row.original, filterValue as DateRangeValue)
+                isJobInActivityDateRange(row.original, filterValue as DateRangeValue)
             ),
             cell: info => formatDateTime(info.getValue()),
         }),

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.utils.test.ts
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildJobActivityDays } from './ActivityWidget.utils';
+import { buildJobActivityDays, isJobInActivityDateRange } from './ActivityWidget.utils';
 
 const timestamp = (
     year: number,
@@ -18,12 +18,13 @@ describe('buildJobActivityDays', () => {
             '2026-05-29',
         ]);
         expect(days.map(day => ({
+            activeCount: day.activeCount,
             failedCount: day.failedCount,
             successCount: day.successCount,
         }))).toEqual([
-            { failedCount: 0, successCount: 0 },
-            { failedCount: 0, successCount: 0 },
-            { failedCount: 0, successCount: 0 },
+            { activeCount: 0, failedCount: 0, successCount: 0 },
+            { activeCount: 0, failedCount: 0, successCount: 0 },
+            { activeCount: 0, failedCount: 0, successCount: 0 },
         ]);
     });
 
@@ -55,6 +56,55 @@ describe('buildJobActivityDays', () => {
         expect(days).toHaveLength(1);
         expect(days[0].failedCount).toBe(1);
         expect(days[0].successCount).toBe(0);
+    });
+
+    it('counts pending and running jobs as active on the current day', () => {
+        const days = buildJobActivityDays([
+            { start_time: null, end_time: null, status: 'PENDING' },
+            { start_time: timestamp(2026, 4, 27, 9), end_time: null, status: 'STARTED' },
+            { start_time: timestamp(2026, 4, 29, 10), end_time: null, status: 'SUCCESS' },
+        ], 3, new Date(2026, 4, 29, 12));
+
+        expect(days.map(day => ({
+            key: day.key,
+            activeCount: day.activeCount,
+            successCount: day.successCount,
+        }))).toEqual([
+            { key: '2026-05-27', activeCount: 0, successCount: 0 },
+            { key: '2026-05-28', activeCount: 0, successCount: 0 },
+            { key: '2026-05-29', activeCount: 2, successCount: 1 },
+        ]);
+    });
+
+    it('filters active jobs by the current activity date', () => {
+        const now = new Date(2026, 4, 29, 12);
+
+        expect(isJobInActivityDateRange({
+            start_time: null,
+            end_time: null,
+            status: 'PENDING',
+        }, {
+            fromDate: '2026-05-29',
+            toDate: '2026-05-29',
+        }, now)).toBe(true);
+
+        expect(isJobInActivityDateRange({
+            start_time: timestamp(2026, 4, 27, 9),
+            end_time: null,
+            status: 'STARTED',
+        }, {
+            fromDate: '2026-05-29',
+            toDate: '2026-05-29',
+        }, now)).toBe(true);
+
+        expect(isJobInActivityDateRange({
+            start_time: null,
+            end_time: null,
+            status: 'PENDING',
+        }, {
+            fromDate: '2026-05-28',
+            toDate: '2026-05-28',
+        }, now)).toBe(false);
     });
 
     it('ignores invalid timestamps and jobs after now', () => {

--- a/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.utils.ts
+++ b/apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.utils.ts
@@ -1,15 +1,18 @@
 import { eachDayOfInterval, format, isAfter, isBefore, startOfDay, subDays } from 'date-fns';
 import type { JobDescription } from '@dhis2-chap/ui';
+import { getDateRangeBounds, type DateRangeValue } from '../../../../utils/jobDateRange';
 
 type JobActivity = Pick<JobDescription, 'start_time' | 'end_time' | 'status'>;
 
 export type JobActivityDay = {
     key: string;
     label: string;
+    activeCount: number;
     failedCount: number;
     successCount: number;
 };
 
+const ACTIVE_JOB_STATUSES = new Set(['PENDING', 'STARTED']);
 const FAILED_JOB_STATUS = 'FAILURE';
 const SUCCESS_JOB_STATUS = 'SUCCESS';
 
@@ -17,9 +20,43 @@ const getDayKey = (date: Date) => format(date, 'yyyy-MM-dd');
 
 const isValidDate = (date: Date) => !Number.isNaN(date.getTime());
 
-const getJobActivityTimestamp = (job: JobActivity) => (
-    job.start_time ?? job.end_time
-);
+const isActiveJob = (job: JobActivity) => ACTIVE_JOB_STATUSES.has(job.status.toUpperCase());
+
+const getJobActivityDate = (job: JobActivity, now: Date) => {
+    if (isActiveJob(job)) {
+        return now;
+    }
+
+    const timestamp = job.start_time ?? job.end_time;
+
+    if (!timestamp) {
+        return undefined;
+    }
+
+    const date = new Date(timestamp);
+
+    return isValidDate(date) ? date : undefined;
+};
+
+export const isJobInActivityDateRange = (
+    job: JobActivity,
+    range: DateRangeValue,
+    now = new Date(),
+) => {
+    const bounds = getDateRangeBounds(range);
+
+    if (!bounds) {
+        return true;
+    }
+
+    const activityDate = getJobActivityDate(job, now);
+
+    if (!activityDate) {
+        return false;
+    }
+
+    return !isBefore(activityDate, bounds.start) && !isAfter(activityDate, bounds.end);
+};
 
 export const buildJobActivityDays = (
     jobs: JobActivity[],
@@ -33,22 +70,18 @@ export const buildJobActivityDays = (
     const countsByDay = new Map(days.map(day => [
         getDayKey(day),
         {
+            activeCount: 0,
             failedCount: 0,
             successCount: 0,
         },
     ]));
 
     jobs.forEach((job) => {
-        const timestamp = getJobActivityTimestamp(job);
-
-        if (!timestamp) {
-            return;
-        }
-
-        const jobDate = new Date(timestamp);
+        const jobDate = getJobActivityDate(job, now);
 
         if (
-            !isValidDate(jobDate)
+            !jobDate
+            || !isValidDate(jobDate)
             || isBefore(jobDate, start)
             || isAfter(jobDate, end)
         ) {
@@ -64,6 +97,10 @@ export const buildJobActivityDays = (
 
         const status = job.status.toUpperCase();
 
+        if (ACTIVE_JOB_STATUSES.has(status)) {
+            counts.activeCount += 1;
+        }
+
         if (status === SUCCESS_JOB_STATUS) {
             counts.successCount += 1;
         }
@@ -76,6 +113,7 @@ export const buildJobActivityDays = (
     return days.map(day => ({
         key: getDayKey(day),
         label: format(day, 'MMM d'),
+        activeCount: countsByDay.get(getDayKey(day))?.activeCount ?? 0,
         failedCount: countsByDay.get(getDayKey(day))?.failedCount ?? 0,
         successCount: countsByDay.get(getDayKey(day))?.successCount ?? 0,
     }));


### PR DESCRIPTION
## Summary

- Add an Active series to the prediction setup recent activity chart for pending and running jobs.
- Treat active jobs as activity for the current day so chart drilldowns include queued/running jobs without timestamps.
- Open the recent activity widget by default on prediction setup dashboards.
- Add a patch changeset for @dhis2-chap/modeling-app.

## Validation

- pnpm exec vitest run apps/modeling-app/src/components/PageContent/ConfiguredModelDashboard/ActivityWidget/ActivityWidget.utils.test.ts
- pnpm --filter @dhis2-chap/modeling-app tsc:check
- pnpm --filter @dhis2-chap/modeling-app linter:check