### PR TITLE
test: add live evaluation lifecycle coverage

### DIFF
--- a/apps/modeling-app/e2e/README.md
+++ b/apps/modeling-app/e2e/README.md
@@ -3,6 +3,50 @@
 ## How it works
 - Playwright runs a `setup` project first (`auth.setup.ts`) to log in and save auth state to `playwright/.auth/user.json`.
 - All `*.spec.ts` tests run in the `chromium` project and reuse that auth state.
+- Tests that need CHAP records create uniquely named data for the run instead of relying on optional pre-existing records.
+
+## What "coverage" means here
+
+Playwright can collect Chromium JavaScript execution coverage through the Chrome
+DevTools Protocol. That number is browser/code coverage: it shows which shipped
+JavaScript bytes or functions executed. It excludes CHAP and DHIS2 backend code,
+is sensitive to bundling and source maps, and does not show whether an important
+user outcome was asserted. It is therefore not a meaningful statistical target
+for this end-to-end suite.
+
+We measure end-to-end coverage as a small inventory of critical user journeys.
+A journey counts as live integration coverage when the test drives the UI,
+uses the real DHIS2/CHAP stack, and asserts a durable outcome such as persisted
+data, navigation, or a created job. Use the discovered test list as the
+reproducible count:
+
+```bash
+pnpm exec playwright test --list
+```
+
+### Baseline
+
+Before the evaluation-management tests were added on 2026-07-25, Playwright
+discovered 10 tests in 5 files: 1 authentication setup and 9 application tests.
+
+| Critical area | Baseline evidence |
+| --- | --- |
+| Authentication and evaluations entry point | Auth setup plus evaluations table smoke test |
+| New evaluation | Period validation, unsaved-change guard, and a live import that reaches a successful job |
+| Evaluation details | A completed live evaluation opens and creates a prediction setup |
+| Prediction setup | A live prediction starts and appears in scoped activity |
+| Models | Archived-model filtering uses a model created and archived through the live API |
+| Evaluation lifecycle management | Not covered |
+
+The two focused client-side validation tests in `new-evaluation-form.spec.ts`
+stub only the create-backtest response so they do not create data; they count as
+form behavior coverage, not live integration coverage. The evaluation-management
+spec closes the lifecycle gap with live rename-persistence and delete journeys,
+bringing the discovered inventory to 12 tests: 1 setup and 11 application tests.
+
+Important remaining gaps include evaluation comparison, configured-model
+creation, prediction result/import, and environment-changing settings. Add
+coverage there only when the live-data setup and assertions can be reliable.
 
 ## Run locally
 From repo root:

--- a/apps/modeling-app/e2e/evaluation-management.spec.ts
+++ b/apps/modeling-app/e2e/evaluation-management.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import type { BacktestRead } from '@dhis2-chap/ui';
+import {
+    chapUrl,
+    createCompletedNaiveEvaluation,
+    readJson,
+} from './helpers/evaluation-fixtures';
+
+test.setTimeout(240_000);
+
+test.describe.serial('evaluation management', () => {
+    let evaluation: BacktestRead;
+    let renamedEvaluationName: string;
+
+    test('renames an evaluation and persists the new name', async ({ page }) => {
+        const originalEvaluationName = `E2E evaluation to manage ${Date.now()}`;
+        evaluation = await createCompletedNaiveEvaluation(page, originalEvaluationName);
+        renamedEvaluationName = `E2E renamed evaluation ${Date.now()}`;
+
+        await page.goto('/#/evaluate');
+
+        await expect(page.getByRole('heading', { name: 'Evaluations' })).toBeVisible();
+        await page.getByPlaceholder('Search').fill(originalEvaluationName);
+
+        const evaluationRow = page.getByRole('row').filter({
+            has: page.getByRole('link', { name: originalEvaluationName, exact: true }),
+        });
+
+        await expect(evaluationRow).toBeVisible();
+        await evaluationRow.getByRole('button', { name: 'More' }).click();
+        await page.locator('[data-test="backtest-overflow-rename"]').click();
+
+        const renameModal = page.locator('[data-test="edit-backtest-modal"]');
+        await expect(renameModal.getByRole('heading', { name: 'Rename evaluation' })).toBeVisible();
+        await renameModal.locator('[data-test="backtest-name-input"] input').fill(renamedEvaluationName);
+
+        const renameResponse = page.waitForResponse(response =>
+            response.request().method() === 'PATCH' &&
+            response.url().includes(`/v1/crud/backtests/${evaluation.id}`),
+        );
+
+        await renameModal.locator('[data-test="submit-edit-backtest-button"]').click();
+
+        const renamedEvaluation = await readJson<BacktestRead>(
+            await renameResponse,
+            'Rename evaluation',
+        );
+
+        expect(renamedEvaluation.name).toBe(renamedEvaluationName);
+        await expect(renameModal).not.toBeVisible();
+        await page.getByPlaceholder('Search').fill(renamedEvaluationName);
+        await expect(page.getByRole('link', { name: renamedEvaluationName, exact: true })).toBeVisible();
+
+        await page.reload();
+
+        await expect(page.getByRole('link', { name: renamedEvaluationName, exact: true })).toBeVisible();
+    });
+
+    test('deletes the renamed evaluation', async ({ page }) => {
+        await page.goto('/#/evaluate');
+        await page.getByPlaceholder('Search').fill(renamedEvaluationName);
+
+        const evaluationRow = page.getByRole('row').filter({
+            has: page.getByRole('link', { name: renamedEvaluationName, exact: true }),
+        });
+
+        await expect(evaluationRow).toBeVisible();
+        await evaluationRow.getByRole('button', { name: 'More' }).click();
+        await page.locator('[data-test="backtest-overflow-delete"]').click();
+
+        const deleteModal = page.locator('[data-test="delete-backtest-modal"]');
+        await expect(deleteModal.getByRole('heading', { name: 'Delete evaluation' })).toBeVisible();
+
+        const deleteResponse = page.waitForResponse(response =>
+            response.request().method() === 'DELETE' &&
+            response.url().includes(`/v1/crud/backtests/${evaluation.id}`),
+        );
+
+        await deleteModal.locator('[data-test="submit-delete-backtest-button"]').click();
+
+        expect((await deleteResponse).ok()).toBe(true);
+        await expect(deleteModal).not.toBeVisible();
+        await expect(page.getByText('Evaluation deleted')).toBeVisible();
+        await expect(evaluationRow).toHaveCount(0);
+
+        const deletedEvaluationResponse = await page.request.get(
+            chapUrl(`/v1/crud/backtests/${evaluation.id}/info`),
+        );
+
+        expect(deletedEvaluationResponse.status()).toBe(404);
+    });
+});

--- a/docker/compose.dhis2.yml
+++ b/docker/compose.dhis2.yml
@@ -8,7 +8,7 @@ services:
         "if [ -f dhis2-demo.dump.gz ]; then echo 'dhis2-demo.dump.gz exists'; exit 0; fi; if [ -f demo.sql.gz ]; then mv demo.sql.gz dhis2-demo.dump.gz; else wget --output-document dhis2-demo.dump.gz \"$$DHIS2_DB_DUMP_URL\"; fi; echo 'Prepared dhis2-demo.dump.gz'",
       ]
     environment:
-      DHIS2_DB_DUMP_URL: ${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/climate/laos/2.42/demo.sql.gz}
+      DHIS2_DB_DUMP_URL: ${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/climate/laos/2.42/laos.sql.gz}
     working_dir: /opt/dump
     volumes:
       - dhis2-db-dump:/opt/dump


### PR DESCRIPTION
## Summary

- add serial Playwright journeys that create one completed evaluation from live DHIS2 analytics, rename it through the UI, verify the rename persists after reload, and delete it through the UI
- document a maintainable end-to-end coverage method and the pre-change baseline
- update the default DHIS2 climate fixture URL after the published dump moved from `demo.sql.gz` to `laos.sql.gz`

## Baseline and measurement

Before this change, `pnpm exec playwright test --list` discovered 10 tests in 5 files: 1 authentication setup and 9 application tests. Those tests covered authentication/evaluation entry, evaluation form behavior and live import, evaluation details, prediction setup/run/activity, and archived-model filtering. Evaluation lifecycle management was not covered.

Playwright can expose Chromium JavaScript execution coverage through the Chrome DevTools Protocol, but that is browser/code coverage rather than test or feature coverage. It excludes CHAP and DHIS2 backend code, changes with bundling and source maps, and cannot show whether an important user outcome was asserted. This PR therefore documents a critical-user-journey inventory backed by `playwright test --list`. After this change, the inventory is 12 tests in 6 files: 1 setup and 11 application tests.

This is a concise, maintainable indicator rather than a statistical claim about total product coverage. Important remaining gaps include evaluation comparison, configured-model creation, prediction result/import, and environment-changing settings.

## Newly covered journeys

The new tests use the real DHIS2/CHAP stack with no network or API mocks. They:

1. build a completed naive evaluation from real DHIS2 analytics and organisation-unit geometry
2. find and rename that evaluation through the UI, assert the live PATCH response, and verify persistence after reload
3. find and delete the renamed evaluation through the UI, assert the live DELETE response and success state, then verify the resource returns 404

The evaluation search filter makes the journeys reliable while specs create data in parallel, and deletion cleans up the created evaluation.

## Verification

- `pnpm exec playwright test --list` — 12 tests discovered in 6 files
- `pnpm exec playwright test apps/modeling-app/e2e/evaluation-management.spec.ts --project=chromium` — 3/3 passed (setup plus 2 new tests)
- `pnpm exec playwright test --project=chromium --workers=1` — 12/12 passed in 42.5s
- `pnpm exec playwright test apps/modeling-app/e2e/new-evaluation-form.spec.ts --project=chromium --grep 'warns before leaving'` — 2/2 passed after a parallel live-service retry
- `pnpm --filter @dhis2-chap/modeling-app linter:check`
- `pnpm --filter @dhis2-chap/modeling-app tsc:check`
- Docker Compose config validation and `git diff --check`

The first local stack start exposed the stale default dump URL with a 404. The current official `laos.sql.gz` fixture initialized successfully, and the full suite above ran against it.
