### PR TITLE
ci: add manual e2e resilience workflow

### DIFF
--- a/.github/workflows/e2e-resilience.yml
+++ b/.github/workflows/e2e-resilience.yml
@@ -1,0 +1,109 @@
+name: e2e-resilience
+
+run-name: e2e-resilience (${{ inputs.profile }}) on ${{ github.ref_name }}
+
+on:
+    workflow_dispatch:
+        inputs:
+            profile:
+                description: Degraded runtime profile
+                required: true
+                default: combined
+                type: choice
+                options:
+                    - combined
+                    - poor-network
+                    - constrained-compute
+            retries:
+                description: Retries per failed test
+                required: true
+                default: '1'
+                type: choice
+                options:
+                    - '0'
+                    - '1'
+                    - '2'
+            workers:
+                description: Parallel Playwright workers
+                required: true
+                default: '1'
+                type: choice
+                options:
+                    - '1'
+                    - '2'
+            timeout_ms:
+                description: Default timeout per test in milliseconds
+                required: true
+                default: '300000'
+                type: choice
+                options:
+                    - '120000'
+                    - '180000'
+                    - '300000'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.profile }}
+    cancel-in-progress: false
+
+jobs:
+    e2e-resilience:
+        runs-on: ubuntu-latest
+        timeout-minutes: 120
+        permissions:
+            contents: read
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright browser
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Start CHAP + DHIS2 stack and wait for readiness
+              run: pnpm docker:e2e up --wait
+
+            - name: Run e2e suite under degraded conditions
+              env:
+                  E2E_RESILIENCE_PROFILE: ${{ inputs.profile }}
+                  E2E_RESILIENCE_RETRIES: ${{ inputs.retries }}
+                  E2E_RESILIENCE_WORKERS: ${{ inputs.workers }}
+                  E2E_RESILIENCE_TIMEOUT_MS: ${{ inputs.timeout_ms }}
+              run: ./scripts/ci/run-e2e-resilience.sh
+
+            - name: Collect runtime diagnostics
+              if: ${{ !cancelled() }}
+              run: |
+                  mkdir -p resilience-diagnostics
+                  pnpm docker:e2e ps > resilience-diagnostics/docker-compose-ps.txt
+                  docker compose \
+                    --project-name "${COMPOSE_PROJECT_NAME:-chap-platform}" \
+                    --env-file docker/.env.example \
+                    -f docker/compose.chap.yml \
+                    -f docker/compose.dhis2.yml \
+                    logs --no-color > resilience-diagnostics/docker-compose.log
+
+            - name: Upload resilience diagnostics
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-resilience-${{ inputs.profile }}-${{ github.run_attempt }}
+                  path: |
+                      playwright-report/
+                      test-results/
+                      resilience-diagnostics/
+                  if-no-files-found: warn
+                  retention-days: 14
+
+            - name: Stop CHAP + DHIS2 stack
+              if: ${{ always() }}
+              run: pnpm docker:e2e down

--- a/docs/e2e-resilience.md
+++ b/docs/e2e-resilience.md
@@ -1,0 +1,119 @@
+# Manual E2E resilience runs
+
+The `e2e-resilience` GitHub Actions workflow runs the normal Playwright suite
+under explicitly degraded conditions. It has only a `workflow_dispatch`
+trigger, so it never runs automatically for a pull request or push.
+
+The workflow starts the same live CHAP and DHIS2 stack as the normal e2e jobs
+and invokes the existing `*.spec.ts` discovery through `playwright test`. New
+tests added to the normal suite are therefore included without maintaining a
+second test list.
+
+## Profiles
+
+| Profile | Impairment | What it represents |
+| --- | --- | --- |
+| `poor-network` | Linux `netem` on loopback: 150 ms delay with 30 ms jitter and 25% correlation, 0.5% packet loss with 25% correlation, and 1.6 Mbit/s rate | A reproducible poor local link for browser, authentication, app, DHIS2, and CHAP traffic |
+| `constrained-compute` | The Playwright command and its browser/web-server descendants are pinned to one allowed logical CPU | Real Linux scheduler affinity and contention between the test runner, browser, and frontend server |
+| `combined` | Both impairments | The default and most demanding profile |
+
+Linux [`netem`](https://man7.org/linux/man-pages/man8/netem.8.html) provides
+kernel-level delay, loss, and rate emulation. The rate and timer behavior are
+still subject to kernel granularity, and packet loss remains stochastic. The
+profile affects loopback traffic because every tested service is exposed on
+localhost; it does not reproduce cellular radio behavior, DNS failures, or
+internet routing.
+
+[`taskset`](https://man7.org/linux/man-pages/man1/taskset.1.html) sets CPU
+affinity. Linux documents that
+[child processes inherit affinity across fork and exec](https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html).
+It limits the Playwright process tree to one logical CPU, but it does not lower
+that CPU's clock speed and it does not constrain the Dockerized CHAP/DHIS2
+backend.
+
+This is not hardware simulation. The workflow records runner CPU and memory,
+but it does not impose a memory limit. Browser memory limits based on virtual
+address space are not representative, while job-wide cgroup limits are not a
+portable GitHub-hosted runner contract. Use a deliberately sized self-hosted
+runner when validating a real low-memory target. GitHub documents the current
+[hosted runner resources](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).
+
+Playwright device emulation changes browser-visible properties such as
+viewport, user agent, and touch support; it does not emulate slower hardware.
+It is intentionally excluded from this desktop resilience job. See
+[Playwright emulation](https://playwright.dev/docs/emulation).
+
+## Trigger a run
+
+In GitHub, open **Actions**, select **e2e-resilience**, choose **Run workflow**,
+select the branch, and set:
+
+- `profile`: degraded condition to apply.
+- `retries`: `0` exposes every first-attempt failure; `1` or `2` preserves
+  evidence of transient failures while allowing recovery.
+- `workers`: Playwright process concurrency. One worker is the most
+  reproducible choice.
+- `timeout_ms`: default per-test timeout. Tests that set their own timeout
+  retain that explicit value.
+
+The equivalent GitHub CLI command is:
+
+```bash
+gh workflow run e2e-resilience.yml \
+  --ref <branch> \
+  -f profile=combined \
+  -f retries=1 \
+  -f workers=1 \
+  -f timeout_ms=300000
+```
+
+GitHub requires a manually dispatched workflow file to exist on the default
+branch before it appears in the Actions UI. Once merged, any branch can be
+selected for a run. See GitHub's
+[manual workflow instructions](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow).
+
+## Interpret failures
+
+The workflow uploads a 14-day artifact containing the HTML report, retained
+videos and failure traces, the active traffic-control rule, runner CPU/memory
+details, container status, and Docker logs.
+
+- A test that fails first and passes on retry is still resilience evidence.
+  Inspect the failed attempt's trace rather than treating the run as clean.
+- Repeated assertion failures usually indicate application behavior that does
+  not tolerate the selected profile.
+- Setup or authentication failures indicate that the whole request path could
+  not tolerate the profile, before a user journey began.
+- A timeout means the journey exceeded the configured or test-specific budget;
+  compare its trace with a normal e2e run before increasing the budget.
+- Infrastructure failures before the test command should be diagnosed from
+  `runtime.txt`, `network.txt`, container status, and Docker logs.
+
+Retries restart the failed Playwright worker and browser. Worker count,
+timeouts, retries, and tracing are test-runner controls rather than hardware
+impairments; see the Playwright documentation for
+[retries](https://playwright.dev/docs/test-retries) and
+[CLI options](https://playwright.dev/docs/test-cli).
+
+## Local validation
+
+On Linux, start the stack and run the same script:
+
+```bash
+pnpm docker:e2e up --wait
+E2E_RESILIENCE_PROFILE=combined ./scripts/ci/run-e2e-resilience.sh
+pnpm docker:e2e down
+```
+
+The network profiles require passwordless `sudo` for `tc` and refuse to
+replace a non-default loopback queue discipline. The script always removes the
+rule it installed when it exits.
+
+On macOS or without changing traffic control, validate profile selection and
+the generated Playwright command with:
+
+```bash
+E2E_RESILIENCE_DRY_RUN=1 \
+  E2E_RESILIENCE_PROFILE=combined \
+  ./scripts/ci/run-e2e-resilience.sh
+```

--- a/scripts/ci/run-e2e-resilience.sh
+++ b/scripts/ci/run-e2e-resilience.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+profile="${E2E_RESILIENCE_PROFILE:-combined}"
+retries="${E2E_RESILIENCE_RETRIES:-1}"
+workers="${E2E_RESILIENCE_WORKERS:-1}"
+timeout_ms="${E2E_RESILIENCE_TIMEOUT_MS:-300000}"
+dry_run="${E2E_RESILIENCE_DRY_RUN:-0}"
+diagnostics_dir="${E2E_RESILIENCE_DIAGNOSTICS_DIR:-resilience-diagnostics}"
+network_configured="false"
+
+fail() {
+    echo "e2e-resilience: $*" >&2
+    exit 1
+}
+
+case "${profile}" in
+poor-network)
+    use_network="true"
+    use_cpu_affinity="false"
+    ;;
+constrained-compute)
+    use_network="false"
+    use_cpu_affinity="true"
+    ;;
+combined)
+    use_network="true"
+    use_cpu_affinity="true"
+    ;;
+*)
+    fail "unsupported profile '${profile}'"
+    ;;
+esac
+
+[[ "${retries}" =~ ^[0-2]$ ]] || fail "retries must be 0, 1, or 2"
+[[ "${workers}" =~ ^[1-4]$ ]] || fail "workers must be between 1 and 4"
+[[ "${timeout_ms}" =~ ^[0-9]+$ ]] || fail "timeout must be an integer"
+((timeout_ms >= 30000 && timeout_ms <= 600000)) ||
+    fail "timeout must be between 30000 and 600000 milliseconds"
+[[ "${dry_run}" == "0" || "${dry_run}" == "1" ]] ||
+    fail "E2E_RESILIENCE_DRY_RUN must be 0 or 1"
+
+test_command=(
+    pnpm exec playwright test
+    "--workers=${workers}"
+    "--retries=${retries}"
+    "--timeout=${timeout_ms}"
+    "--reporter=line,html"
+    "--trace=retain-on-failure"
+)
+
+cpu_id=""
+if [[ "${use_cpu_affinity}" == "true" ]]; then
+    if [[ "${dry_run}" == "0" ]]; then
+        command -v taskset >/dev/null ||
+            fail "taskset is required for the constrained-compute profile"
+    fi
+
+    if [[ "$(uname -s)" == "Linux" && -r /proc/self/status ]]; then
+        allowed_cpu_list="$(awk '/^Cpus_allowed_list:/ { print $2 }' /proc/self/status)"
+        first_cpu_range="${allowed_cpu_list%%,*}"
+        cpu_id="${first_cpu_range%%-*}"
+    elif [[ "${dry_run}" == "0" ]]; then
+        fail "the constrained-compute profile requires Linux CPU affinity support"
+    else
+        cpu_id="0"
+    fi
+
+    [[ "${cpu_id}" =~ ^[0-9]+$ ]] || fail "unable to resolve an allowed CPU"
+    test_command=(taskset --cpu-list "${cpu_id}" "${test_command[@]}")
+fi
+
+if [[ "${dry_run}" == "1" ]]; then
+    printf 'profile=%s network=%s cpu=%s command=' \
+        "${profile}" "${use_network}" "${use_cpu_affinity}"
+    printf '%q ' "${test_command[@]}"
+    printf '\n'
+    exit 0
+fi
+
+[[ "$(uname -s)" == "Linux" ]] ||
+    fail "resilience execution requires Linux; use E2E_RESILIENCE_DRY_RUN=1 elsewhere"
+
+mkdir -p "${diagnostics_dir}"
+
+cleanup() {
+    if [[ "${network_configured}" == "true" ]]; then
+        sudo tc qdisc del dev lo root >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+{
+    echo "profile=${profile}"
+    echo "retries=${retries}"
+    echo "workers=${workers}"
+    echo "timeout_ms=${timeout_ms}"
+    echo "cpu_affinity=${cpu_id:-none}"
+    echo "recorded_at=$(date --utc +%Y-%m-%dT%H:%M:%SZ)"
+    uname -a
+    lscpu
+    free -h
+} > "${diagnostics_dir}/runtime.txt"
+
+if [[ "${use_network}" == "true" ]]; then
+    command -v tc >/dev/null || fail "tc is required for the poor-network profile"
+    sudo -n true ||
+        fail "passwordless sudo is required to configure loopback traffic control"
+
+    existing_qdisc="$(tc qdisc show dev lo)"
+    if ! grep -q 'qdisc noqueue.*root' <<< "${existing_qdisc}"; then
+        fail "refusing to replace an existing loopback queue discipline: ${existing_qdisc}"
+    fi
+
+    sudo tc qdisc add dev lo root netem \
+        delay 150ms 30ms 25% distribution normal \
+        loss random 0.5% 25% \
+        rate 1600kbit
+    network_configured="true"
+    sudo tc qdisc show dev lo > "${diagnostics_dir}/network.txt"
+fi
+
+printf 'Running: '
+printf '%q ' "${test_command[@]}"
+printf '\n'
+"${test_command[@]}"


### PR DESCRIPTION
## Summary

- add a `workflow_dispatch`-only Playwright resilience workflow with configurable degraded profiles, retries, workers, and test timeout
- emulate a poor localhost link with Linux `netem` and constrain the Playwright/browser/frontend process tree to one logical CPU with `taskset`
- retain HTML, video, trace, runner, traffic-control, and Docker diagnostics for failure analysis
- document triggering, failure interpretation, local validation, and the boundary between real scheduler/network constraints and hardware approximations

## Scope and coordination

This is additive infrastructure. It does not change Playwright configuration, package scripts, authentication, normal CI, or e2e specs. It invokes the existing unfiltered `playwright test` contract, so new `*.spec.ts` coverage is discovered automatically.

The concurrent normal-coverage work owns `apps/modeling-app/e2e/README.md`, the new live-data spec, and a one-line fix for the stale default DHIS2 dump URL. This PR deliberately keeps using `pnpm docker:e2e up --wait` and does not duplicate that override.

## Validation

- `actionlint .github/workflows/e2e-resilience.yml`
- `bash -n scripts/ci/run-e2e-resilience.sh`
- dry-run command generation for `poor-network`, `constrained-compute`, and `combined`, including invalid-input rejection
- `pnpm exec playwright test --list --workers=1 --retries=1 --timeout=300000 --reporter=line,html --trace=retain-on-failure`
- `pnpm linter:check`
- `pnpm build`
- `pnpm tsc:check`
- `git diff --check`

The actual Linux impairment run cannot be executed on this macOS worktree. The manual workflow also cannot be dispatched until the workflow file exists on the default branch; this limitation and the equivalent Linux local command are documented.
