### PR TITLE
test: add live evaluation comparison coverage

### DIFF
--- a/apps/modeling-app/e2e/README.md
+++ b/apps/modeling-app/e2e/README.md
@@ -34,6 +34,7 @@ discovered 10 tests in 5 files: 1 authentication setup and 9 application tests.
 | Authentication and evaluations entry point | Auth setup plus evaluations table smoke test |
 | New evaluation | Period validation, unsaved-change guard, and a live import that reaches a successful job |
 | Evaluation details | A completed live evaluation opens and creates a prediction setup |
+| Evaluation comparison | Not covered |
 | Prediction setup | A live prediction starts and appears in scoped activity |
 | Models | Archived-model filtering uses a model created and archived through the live API |
 | Evaluation lifecycle management | Not covered |
@@ -42,11 +43,13 @@ The two focused client-side validation tests in `new-evaluation-form.spec.ts`
 stub only the create-backtest response so they do not create data; they count as
 form behavior coverage, not live integration coverage. The evaluation-management
 spec closes the lifecycle gap with live rename-persistence and delete journeys,
-bringing the discovered inventory to 12 tests: 1 setup and 11 application tests.
+and the evaluation-comparison spec covers live compatible selection, chart data,
+and URL restoration. Together they bring the discovered inventory to 13 tests:
+1 setup and 12 application tests.
 
-Important remaining gaps include evaluation comparison, configured-model
-creation, prediction result/import, and environment-changing settings. Add
-coverage there only when the live-data setup and assertions can be reliable.
+Important remaining gaps include configured-model creation, prediction
+result/import, and environment-changing settings. Add coverage there only when
+the live-data setup and assertions can be reliable.
 
 ## Run locally
 From repo root:

--- a/apps/modeling-app/e2e/evaluation-comparison.spec.ts
+++ b/apps/modeling-app/e2e/evaluation-comparison.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '@playwright/test';
+import type { BacktestDomain, BacktestRead } from '@dhis2-chap/ui';
+import {
+    chapUrl,
+    createCompletedNaiveEvaluation,
+    readJson,
+} from './helpers/evaluation-fixtures';
+
+test.setTimeout(240_000);
+
+const createdEvaluationIds: number[] = [];
+
+test.afterEach(async ({ request }) => {
+    await Promise.all(
+        createdEvaluationIds.map(async (evaluationId) => {
+            const response = await request.delete(
+                chapUrl(`/v1/crud/backtests/${evaluationId}`),
+            );
+
+            expect(response.ok()).toBe(true);
+        }),
+    );
+    createdEvaluationIds.length = 0;
+});
+
+test('compares two completed evaluations and restores the comparison from the URL', async ({
+    page,
+}) => {
+    const runId = Date.now();
+    const baseEvaluationName = `E2E comparison base ${runId}`;
+    const comparisonEvaluationName = `E2E comparison candidate ${runId}`;
+    const baseEvaluation = await createCompletedNaiveEvaluation(
+        page,
+        baseEvaluationName,
+    );
+    createdEvaluationIds.push(baseEvaluation.id);
+
+    const comparisonEvaluation = await createCompletedNaiveEvaluation(
+        page,
+        comparisonEvaluationName,
+    );
+    createdEvaluationIds.push(comparisonEvaluation.id);
+
+    await page.goto(`/#/evaluate/${baseEvaluation.id}`);
+    await expect(
+        page.getByRole('heading', { name: 'Evaluation details' }),
+    ).toBeVisible();
+
+    const compatibleEvaluationsResponse = page.waitForResponse(response =>
+        response.request().method() === 'GET' &&
+        response.url().includes(
+            `/v1/analytics/compatible-backtests/${baseEvaluation.id}`,
+        ),
+    );
+
+    await page.locator('[data-test="quick-action-compare"]').click();
+
+    await expect(
+        page.getByRole('heading', { name: 'Compare evaluations' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Back to evaluation details' }),
+    ).toBeVisible();
+
+    const compatibleEvaluations = await readJson<BacktestRead[]>(
+        await compatibleEvaluationsResponse,
+        'Load compatible evaluations',
+    );
+
+    expect(compatibleEvaluations).toContainEqual(
+        expect.objectContaining({
+            id: comparisonEvaluation.id,
+            name: comparisonEvaluationName,
+        }),
+    );
+
+    await page.getByText(
+        'Select evaluation to compare with',
+        { exact: true },
+    ).click();
+
+    const overlapResponse = page.waitForResponse(response =>
+        response.request().method() === 'GET' &&
+        response.url().includes(
+            `/v1/analytics/backtest-overlap/${baseEvaluation.id}/${comparisonEvaluation.id}`,
+        ),
+    );
+    const comparisonPlotDataResponse = page.waitForResponse((response) => {
+        if (
+            response.request().method() !== 'GET'
+            || !response.url().includes('/v1/analytics/evaluation-entry')
+        ) {
+            return false;
+        }
+
+        return new URL(response.url()).searchParams.get('backtestId')
+            === comparisonEvaluation.id.toString();
+    });
+
+    await page.getByText(comparisonEvaluationName, { exact: true }).click();
+
+    const overlap = await readJson<BacktestDomain>(
+        await overlapResponse,
+        'Load evaluation overlap',
+    );
+
+    expect(overlap.orgUnits.length).toBeGreaterThan(0);
+    expect(overlap.splitPeriods.length).toBeGreaterThan(0);
+    expect((await comparisonPlotDataResponse).ok()).toBe(true);
+
+    await expect.poll(() => {
+        const hashQuery = new URL(page.url()).hash.split('?')[1] ?? '';
+        return Object.fromEntries(new URLSearchParams(hashQuery));
+    }).toMatchObject({
+        baseEvaluation: baseEvaluation.id.toString(),
+        comparisonEvaluation: comparisonEvaluation.id.toString(),
+    });
+
+    await expect(
+        page.getByText(`Evaluation: ${baseEvaluationName}`, {
+            exact: true,
+        }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+        page.getByText(`Evaluation: ${comparisonEvaluationName}`, {
+            exact: true,
+        }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Split period', { exact: true }))
+        .toBeVisible();
+
+    await page.reload();
+
+    await expect(
+        page.getByText(`Evaluation: ${baseEvaluationName}`, {
+            exact: true,
+        }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+        page.getByText(`Evaluation: ${comparisonEvaluationName}`, {
+            exact: true,
+        }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+});


### PR DESCRIPTION
## Summary

- add a live-stack Playwright journey that creates two completed naive evaluations from real DHIS2 analytics
- enter comparison from evaluation details, verify the live compatibility and overlap APIs, and render both evaluation charts
- reload the parameterized comparison URL and verify both selections and charts are restored
- clean up both created evaluations after the test and update the E2E journey inventory

## User journey covered

1. Create two uniquely named completed evaluations through the existing live fixture helper.
2. Open the base evaluation details page and choose Compare with....
3. Confirm the second evaluation is returned by the live compatible-backtests endpoint and select it in the UI.
4. Confirm the live overlap contains organisation units and split periods, and that comparison plot data loads successfully.
5. Verify both named evaluation charts and the split-period control are visible.
6. Reload the URL and verify the comparison is reconstructed from its baseEvaluation and comparisonEvaluation parameters.
7. Delete both created evaluations through the live API cleanup hook.

## Validation

- pnpm exec playwright test apps/modeling-app/e2e/evaluation-comparison.spec.ts --project=chromium — 2/2 passed in 18.6s
- pnpm exec playwright test --project=chromium --workers=1 — 13/13 passed in 1.0m
- pnpm exec playwright test --list — 13 tests discovered in 7 files
- pnpm --filter @dhis2-chap/core build
- pnpm --filter @dhis2-chap/ui build
- pnpm --filter @dhis2-chap/modeling-app linter:check
- pnpm --filter @dhis2-chap/modeling-app tsc:check
- git diff --check

## Live-environment notes

- This test uses the real local DHIS2, CHAP, worker, Redis, and Postgres stack; it does not mock APIs or network calls.
- The test depends on the evaluation fixture helper and Laos DHIS2 dump URL update in draft PR #231, so this PR is intentionally stacked on that branch.
- Local localhost access required running Playwright outside the Codex sandbox. The completed targeted and full-suite runs above exercised the live stack successfully.
